### PR TITLE
chore: remove excess judgment code

### DIFF
--- a/internal/controller/answer_controller.go
+++ b/internal/controller/answer_controller.go
@@ -284,10 +284,6 @@ func (ac *AnswerController) Add(ctx *gin.Context) {
 	objectOwner := ac.rankService.CheckOperationObjectOwner(ctx, req.UserID, info.ID)
 	req.CanEdit = canList[0] || objectOwner
 	req.CanDelete = canList[1] || objectOwner
-	if !can {
-		handler.HandleResponse(ctx, errors.Forbidden(reason.RankFailToMeetTheCondition), nil)
-		return
-	}
 	info.MemberActions = permission.GetAnswerPermission(ctx, req.UserID, info.UserID,
 		0, req.CanEdit, req.CanDelete, false)
 	handler.HandleResponse(ctx, nil, gin.H{


### PR DESCRIPTION
In the implementation of the `Add` method in `AnswerController`, there are redundant judgment statements.

https://github.com/apache/answer/blob/5886c1ec53087520ac02cbdaf9811a0cfebc829e/internal/controller/answer_controller.go#L240

https://github.com/apache/answer/blob/5886c1ec53087520ac02cbdaf9811a0cfebc829e/internal/controller/answer_controller.go#L287