### PR TITLE
chore: instance rand.Seed to rand.Source

### DIFF
--- a/pkg/uid/id.go
+++ b/pkg/uid/id.go
@@ -34,9 +34,9 @@ type SnowFlakeID struct {
 var snowFlakeIDGenerator *SnowFlakeID
 
 func init() {
-	// todo
-	rand.Seed(time.Now().UnixNano())
-	node, err := snowflake.NewNode(int64(rand.Intn(1000)) + 1)
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+	node, err := snowflake.NewNode(int64(r.Intn(1000)) + 1)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
The `rand.Seed` method is currently deprecated, use rand Replace with the `NewSource` method.

```
// Deprecated: As of Go 1.20 there is no reason to call Seed with
// a random value. Programs that call Seed with a known value to get
// a specific sequence of results should use New(NewSource(seed)) to
// obtain a local random generator.
```