### PR TITLE
revert: fix HasNewTag return value inconsistency in TagCommonService (#1245)

### DIFF
--- a/internal/service/tag_common/tag_common.go
+++ b/internal/service/tag_common/tag_common.go
@@ -291,18 +291,24 @@ func (ts *TagCommonService) ExistRecommend(ctx context.Context, tags []*schema.T
 
 func (ts *TagCommonService) HasNewTag(ctx context.Context, tags []*schema.TagItem) (bool, error) {
 	tagNames := make([]string, 0)
-	tagMap := make(map[string]struct{})
+	tagMap := make(map[string]bool)
 	for _, item := range tags {
 		item.SlugName = strings.ReplaceAll(item.SlugName, " ", "-")
 		tagNames = append(tagNames, item.SlugName)
-		tagMap[item.SlugName] = struct{}{}
+		tagMap[item.SlugName] = false
 	}
 	list, err := ts.GetTagListByNames(ctx, tagNames)
 	if err != nil {
 		return true, err
 	}
 	for _, item := range list {
-		if _, ok := tagMap[item.SlugName]; !ok {
+		_, ok := tagMap[item.SlugName]
+		if ok {
+			tagMap[item.SlugName] = true
+		}
+	}
+	for _, has := range tagMap {
+		if !has {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
This PR reverts commit 5f468c6f054ac096cb1fc31fa5acfbdb8b730c75 to address the issue reported in #1245.

Issue:
After the optimization of HasNewTag function in TagCommonService, there is an inconsistency in return values between the old and new logic. When users edit an existing question and add a new tag, the function incorrectly returns false instead of the expected true value.

Steps to reproduce:
1. Open an existing question and edit it
2. Add a new tag that does not exist
3. Submit the changes
4. The function returns false (incorrect) instead of true (expected)

Impact:
- Affects version 1.42
- Permission validation can be bypassed to create new tags when operating questions via API