### PR TITLE
fix: i18n key of ready_desc

### DIFF
--- a/ui/src/pages/Install/components/FifthStep/index.tsx
+++ b/ui/src/pages/Install/components/FifthStep/index.tsx
@@ -35,7 +35,7 @@ const Index: FC<Props> = ({ visible, siteUrl = '' }) => {
     <div>
       <h5>{t('ready_title')}</h5>
       <p>
-        <Trans i18nKey="install.ready_description">
+        <Trans i18nKey="install.ready_desc">
           If you ever feel like changing more settings, visit
           <a href={`${siteUrl}/users/login`}> admin section</a>; find it in the
           site menu.


### PR DESCRIPTION
The i18n key is incorrect; it should be ready_desc, so the text is displayed in English.
![image](https://github.com/user-attachments/assets/92dff13c-ac32-496e-b382-4494c447c991)
