### PR TITLE
Fix the multi-language translation failure on the installation completion page.

### DIFF
--- a/ui/src/pages/Install/components/FifthStep/index.tsx
+++ b/ui/src/pages/Install/components/FifthStep/index.tsx
@@ -35,7 +35,7 @@ const Index: FC<Props> = ({ visible, siteUrl = '' }) => {
     <div>
       <h5>{t('ready_title')}</h5>
       <p>
-        <Trans i18nKey="install.ready_description">
+        <Trans i18nKey="install.ready_desc">
           If you ever feel like changing more settings, visit
           <a href={`${siteUrl}/users/login`}> admin section</a>; find it in the
           site menu.


### PR DESCRIPTION
Fix the multi-language translation failure caused by the incorrect i18nKey value on the installation completion page.