### PR TITLE
fix(install): update language in logged user info store

### DIFF
--- a/ui/src/pages/Install/index.tsx
+++ b/ui/src/pages/Install/index.tsx
@@ -22,8 +22,6 @@ import { Container, Row, Col, Card, Alert } from 'react-bootstrap';
 import { useTranslation, Trans } from 'react-i18next';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 
-import { useStore } from 'zustand';
-
 import type { FormDataType } from '@/common/interface';
 import {
   dbCheck,
@@ -140,7 +138,7 @@ const Index: FC = () => {
     },
   });
 
-  const { update, user } = useStore(loggedUserInfoStore);
+  const { update, user } = loggedUserInfoStore();
 
   const updateFormData = (params: FormDataType) => {
     if (Object.keys(params)?.[0] === 'db_type') {

--- a/ui/src/pages/Install/index.tsx
+++ b/ui/src/pages/Install/index.tsx
@@ -22,6 +22,8 @@ import { Container, Row, Col, Card, Alert } from 'react-bootstrap';
 import { useTranslation, Trans } from 'react-i18next';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 
+import { useStore } from 'zustand';
+
 import type { FormDataType } from '@/common/interface';
 import {
   dbCheck,
@@ -38,6 +40,7 @@ import {
 import { CURRENT_LANG_STORAGE_KEY } from '@/common/constants';
 import { BASE_ORIGIN } from '@/router/alias';
 import { setupInstallLanguage } from '@/utils/localize';
+import { loggedUserInfoStore } from '@/stores';
 
 import {
   FirstStep,
@@ -136,6 +139,8 @@ const Index: FC = () => {
       errorMsg: '',
     },
   });
+
+  const { update, user } = useStore(loggedUserInfoStore);
 
   const updateFormData = (params: FormDataType) => {
     if (Object.keys(params)?.[0] === 'db_type') {
@@ -248,6 +253,10 @@ const Index: FC = () => {
   const handleStep = () => {
     if (step === 1) {
       Storage.set(CURRENT_LANG_STORAGE_KEY, formData.lang.value);
+      update({
+        ...user,
+        language: formData.lang.value,
+      });
       handleNext();
     }
     if (step === 2) {


### PR DESCRIPTION
When switching the language during installation, the language in the store was not updated, which caused the Accept-Language in the request interceptor to always be set as the default language.
![image](https://github.com/user-attachments/assets/18327dcd-d672-44e8-912c-323ff2d3073b)
