### PR TITLE
 fix old json schema for init SiteInfo.write

### DIFF
--- a/internal/migrations/init.go
+++ b/internal/migrations/init.go
@@ -23,8 +23,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/apache/answer/internal/base/constant"
 	"time"
+
+	"github.com/apache/answer/internal/base/constant"
 
 	"github.com/apache/answer/internal/base/data"
 	"github.com/apache/answer/internal/repo/unique"
@@ -253,11 +254,15 @@ func (m *Mentor) initSiteInfoPrivilegeRank() {
 
 func (m *Mentor) initSiteInfoWrite() {
 	writeData := map[string]interface{}{
-		"restrict_answer":       true,
-		"max_image_size":        4,
-		"max_attachment_size":   8,
-		"max_image_megapixel":   40,
-		"authorized_extensions": []string{"jpg", "jpeg", "png", "gif", "webp"},
+		"restrict_answer":                  true,
+		"required_tag":                     false,
+		"recommend_tags":                   []string{},
+		"reserved_tags":                    []string{},
+		"max_image_size":                   4,
+		"max_attachment_size":              8,
+		"max_image_megapixel":              40,
+		"authorized_image_extensions":      []string{"jpg", "jpeg", "png", "gif", "webp"},
+		"authorized_attachment_extensions": []string{},
 	}
 	writeDataBytes, _ := json.Marshal(writeData)
 	_, m.err = m.engine.Context(m.ctx).Insert(&entity.SiteInfo{

--- a/ui/src/pages/Admin/Write/index.tsx
+++ b/ui/src/pages/Admin/Write/index.tsx
@@ -53,22 +53,22 @@ const initFormData = {
     isInvalid: false,
   },
   max_image_size: {
-    value: 4,
+    value: 0,
     errorMsg: '',
     isInvalid: false,
   },
   max_attachment_size: {
-    value: 8,
+    value: 0,
     errorMsg: '',
     isInvalid: false,
   },
   max_image_megapixel: {
-    value: 40,
+    value: 0,
     errorMsg: '',
     isInvalid: false,
   },
   authorized_image_extensions: {
-    value: 'jpg, jpeg, png, gif, webp',
+    value: '',
     errorMsg: '',
     isInvalid: false,
   },


### PR DESCRIPTION
For first initialization, fill in the wrong json schema.

The problem is hard to detect because the admin page shows default placeholders, but the `/answer/api/v1/siteinfo` method returns `authorized_image_extensions=null` and because of this, the image cannot be loaded.

<img width="686" alt="Screenshot 2025-02-24 at 14 24 38" src="https://github.com/user-attachments/assets/d9099e47-4fa2-4ae3-b8e7-288931c5ebcf" />
