### PR TITLE
fix: get tag with page nil pointer error

### DIFF
--- a/internal/controller/tag_controller.go
+++ b/internal/controller/tag_controller.go
@@ -274,6 +274,10 @@ func (tc *TagController) GetTagWithPage(ctx *gin.Context) {
 	req.UserID = middleware.GetLoginUserIDFromContext(ctx)
 
 	resp, err := tc.tagService.GetTagWithPage(ctx, req)
+	if err != nil {
+		handler.HandleResponse(ctx, err, nil)
+		return
+	}
 	if pager.ValPageOutOfRange(resp.Count, req.Page, req.PageSize) {
 		handler.HandleResponse(ctx, errors.NotFound(reason.RequestFormatError), nil)
 		return


### PR DESCRIPTION
When `tc.tagService.GetTagWithPage` exception, resp will get nil value, `resp.XXX` trigger nil pointer error.