### PR TITLE
fix(ui): correct hover background color for dark theme in reaction button

### DIFF
--- a/ui/src/pages/Questions/Detail/index.scss
+++ b/ui/src/pages/Questions/Detail/index.scss
@@ -24,6 +24,9 @@
       border-color: transparent;
 
       &:hover {
+        [data-bs-theme='dark'] & {
+          background-color: var(--bs-gray-800);
+        }
         background-color: var(--bs-gray-100);
       }
 


### PR DESCRIPTION
Close #1258 .

Changed to `gray-800` for dark theme, cause `900` is quite invisible.

<img width="235" alt="image" src="https://github.com/user-attachments/assets/a73c2273-b9aa-4b8d-b0ae-c2102f437387" />
