### PR TITLE
fix: dedup questions in GetQuestionPage

### DIFF
--- a/internal/repo/question/question_repo.go
+++ b/internal/repo/question/question_repo.go
@@ -404,6 +404,7 @@ func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int,
 	if showPending {
 		status = append(status, entity.QuestionStatusPending)
 	}
+	session.Select("question.*")
 	session.In("question.status", status)
 	if len(tagIDs) > 0 {
 		session.Join("LEFT", "tag_rel", "question.id = tag_rel.object_id")
@@ -442,6 +443,7 @@ func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int,
 		session.OrderBy("question.pin DESC, question.linked_count DESC, question.updated_at DESC")
 	}
 
+	session.GroupBy("question.id")
 	total, err = pager.Help(page, pageSize, &questionList, &entity.Question{}, session)
 	if err != nil {
 		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()


### PR DESCRIPTION
Close #1310 .

I planned to use `session.Distinct("question.*")` but met error when it execute `FindAndCount` in Help func. The current approach works for `FindAndCount`. The SQL looks like

```sql
[xorm] [info]  2025/04/15 22:00:52.962709 [SQL] SELECT question.* FROM `question` LEFT JOIN `tag_rel` ON question.id = tag_rel.object_id WHERE `question`.`status` IN (?,?) AND `tag_rel`.`tag_id` IN (?,?,?) AND (tag_rel.status = ?) AND (question.show = ?) GROUP BY question.id ORDER BY question.pin desc,question.created_at DESC LIMIT 10 [1 2 10030000000000041 10030000000000042 10030000000000002 1 1] - 737.525µs

[xorm] [info]  2025/04/15 22:00:52.963977 [SQL] SELECT count(*) FROM (SELECT question.id FROM `question` LEFT JOIN `tag_rel` ON question.id = tag_rel.object_id WHERE `question`.`status` IN (?,?) AND `tag_rel`.`tag_id` IN (?,?,?) AND (tag_rel.status = ?) AND (question.show = ?) GROUP BY question.id) sub [1 2 10030000000000041 10030000000000042 10030000000000002 1 1] - 418.635µs
```

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/40b73f89-0618-4c3b-991d-cb9a73c9bfef" />
