### PR TITLE
fix(ui): implement dark mode support for reaction buttons

### DIFF
--- a/ui/src/pages/Questions/Detail/components/Reactions/index.tsx
+++ b/ui/src/pages/Questions/Detail/components/Reactions/index.tsx
@@ -26,6 +26,7 @@ import classNames from 'classnames';
 import { Icon } from '@/components';
 import { queryReactions, updateReaction } from '@/services';
 import { tryNormalLogged } from '@/utils/guard';
+import { isDarkTheme } from '@/utils/common';
 import { ReactionItem } from '@/common/interface';
 
 interface Props {
@@ -60,6 +61,7 @@ const Index: FC<Props> = ({
   const [reactions, setReactions] = useState<ReactionItem[]>();
   const [reactIsActive, setReactIsActive] = useState<boolean>(false);
   const { t } = useTranslation('translation');
+  const darkMode = isDarkTheme();
 
   useEffect(() => {
     queryReactions(objectId).then((res) => {
@@ -94,7 +96,7 @@ const Index: FC<Props> = ({
                 : t(`reaction.${d.name}`)
             }
             key={d.icon}
-            variant="light"
+            variant={darkMode ? 'dark' : 'light'}
             active={reactions?.find((v) => v.emoji === d.name)?.is_active}
             className={`${index !== 0 ? 'ms-1' : ''}`}
             size="sm"
@@ -116,7 +118,7 @@ const Index: FC<Props> = ({
       {showAddCommentBtn && (
         <Button
           className="rounded-pill me-2 link-secondary"
-          variant="light"
+          variant={darkMode ? 'dark' : 'light'}
           size="sm"
           onClick={handleClickComment}>
           <Icon name="chat-text-fill" />
@@ -136,7 +138,7 @@ const Index: FC<Props> = ({
           aria-haspopup="true"
           active={reactIsActive}
           className="smile-btn rounded-pill link-secondary"
-          variant="light">
+          variant={darkMode ? 'dark' : 'light'}>
           <Icon name="emoji-smile-fill" />
           <span className="ms-1">+</span>
         </Button>
@@ -165,7 +167,7 @@ const Index: FC<Props> = ({
                   : t('reaction.react_emoji', { emoji: data.emoji })
               }
               aria-pressed="true"
-              variant="light"
+              variant={darkMode ? 'dark' : 'light'}
               active={data.is_active}
               size="sm"
               onClick={() =>

--- a/ui/src/pages/Questions/Detail/components/Reactions/index.tsx
+++ b/ui/src/pages/Questions/Detail/components/Reactions/index.tsx
@@ -117,7 +117,7 @@ const Index: FC<Props> = ({
       })}>
       {showAddCommentBtn && (
         <Button
-          className="rounded-pill me-2 link-secondary"
+          className="rounded-pill me-2 link-secondary btn-reaction"
           variant={darkMode ? 'dark' : 'light'}
           size="sm"
           onClick={handleClickComment}>
@@ -137,7 +137,7 @@ const Index: FC<Props> = ({
           aria-label={t('reaction.btn_label')}
           aria-haspopup="true"
           active={reactIsActive}
-          className="smile-btn rounded-pill link-secondary"
+          className="smile-btn rounded-pill link-secondary btn-reaction"
           variant={darkMode ? 'dark' : 'light'}>
           <Icon name="emoji-smile-fill" />
           <span className="ms-1">+</span>
@@ -160,7 +160,7 @@ const Index: FC<Props> = ({
               </Tooltip>
             }>
             <Button
-              className="rounded-pill ms-2 link-secondary d-flex align-items-center"
+              className="rounded-pill ms-2 link-secondary d-flex align-items-center btn-reaction"
               aria-label={
                 data?.is_active
                   ? t('reaction.unreact_emoji', { emoji: data.emoji })

--- a/ui/src/pages/Questions/Detail/index.scss
+++ b/ui/src/pages/Questions/Detail/index.scss
@@ -27,11 +27,17 @@
         [data-bs-theme='dark'] & {
           background-color: var(--bs-gray-800);
         }
+
         background-color: var(--bs-gray-100);
       }
 
-      &:active, &.active {
+      &:active,
+      &.active {
         background-color: var(--bs-gray-200);
+
+        [data-bs-theme='dark'] & {
+          background-color: var(--bs-gray-800);
+        }
       }
     }
   }

--- a/ui/src/pages/Questions/Detail/index.scss
+++ b/ui/src/pages/Questions/Detail/index.scss
@@ -36,9 +36,22 @@
         background-color: var(--bs-gray-200);
 
         [data-bs-theme='dark'] & {
-          background-color: var(--bs-gray-800);
+          background-color: var(--bs-gray-700);
         }
       }
+    }
+  }
+}
+
+.btn-reaction {
+  [data-bs-theme='dark'] & {
+    color: var(--bs-gray-400) !important;
+    background-color: var(--bs-gray-800);
+    &:active, &.active {
+      background-color: #626E79 !important;
+    }
+    &:hover {
+      background-color: #57616B !important;
     }
   }
 }


### PR DESCRIPTION
Fix #1258 .

Used the default dark variant for button. Pls let me if it works or not. Thanks!

<img width="330" alt="image" src="https://github.com/user-attachments/assets/2daf5eef-ea3b-4e1b-914c-a078de268da3" />

hover.
<img width="339" alt="image" src="https://github.com/user-attachments/assets/d3c86d05-9cf8-43ce-a0c1-58f1fc12a28b" />
