### PR TITLE
chore(configs/config.yaml): Change `api_url` to `api_base_url`

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -38,6 +38,6 @@ service_config:
   purge_deleted_files_period_days: 30
 ui:
   public_url: '/'
-  api_url: '/'
   base_url: ''
+  api_base_url: ''
 


### PR DESCRIPTION
In configs/config.yaml

https://github.com/apache/answer/blob/530812f81097cbab0c2b42b163539bf03b5aa54f/configs/config.yaml#L41

But the name is different in internal/base/server/config.go

https://github.com/apache/answer/blob/530812f81097cbab0c2b42b163539bf03b5aa54f/internal/base/server/config.go#L30