### PR TITLE
fix: AI chat calls semantic_search and errors out when no VectorSearch plugin is enabled

### DIFF
--- a/internal/controller/ai_controller.go
+++ b/internal/controller/ai_controller.go
@@ -43,6 +43,7 @@ import (
 	tagcommonser "github.com/apache/answer/internal/service/tag_common"
 	usercommon "github.com/apache/answer/internal/service/user_common"
 	"github.com/apache/answer/pkg/token"
+	"github.com/apache/answer/plugin"
 	"github.com/gin-gonic/gin"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/sashabaranov/go-openai"
@@ -672,7 +673,11 @@ func (c *AIController) sendErrorResponse(w http.ResponseWriter, id, model, error
 // getMCPTools
 func (c *AIController) getMCPTools() []openai.Tool {
 	openaiTools := make([]openai.Tool, 0)
+	vectorSearchEnabled := plugin.IsVectorSearchEnabled()
 	for _, mcpTool := range mcp_tools.MCPToolsList {
+		if mcpTool.Name == "semantic_search" && !vectorSearchEnabled {
+			continue
+		}
 		openaiTool := c.convertMCPToolToOpenAI(mcpTool)
 		openaiTools = append(openaiTools, openaiTool)
 	}

--- a/plugin/vector_search.go
+++ b/plugin/vector_search.go
@@ -124,6 +124,16 @@ var (
 	registerVectorSearch = MakePlugin[VectorSearch](false)
 )
 
+// IsVectorSearchEnabled reports whether at least one VectorSearch plugin is currently enabled.
+func IsVectorSearchEnabled() bool {
+	enabled := false
+	_ = CallVectorSearch(func(vs VectorSearch) error {
+		enabled = true
+		return nil
+	})
+	return enabled
+}
+
 // GenerateEmbedding is a base utility function that generates an embedding vector
 // using an OpenAI-compatible API. Plugins that don't have a built-in vectorizer
 // (most vector databases) can call this function with their own credentials.


### PR DESCRIPTION
Fix #1532 

As issue mentioned.

Changes have been validated when there's no `vector_search` plugin enabled. Feel free to let me know if any suggestions! :)