### PR TITLE
fix: tag search never matches on slug name

### DIFF
--- a/internal/repo/tag_common/tag_common_repo.go
+++ b/internal/repo/tag_common/tag_common_repo.go
@@ -21,7 +21,6 @@ package tag_common
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -171,10 +170,20 @@ func (tr *tagCommonRepo) GetTagPage(ctx context.Context, page, pageSize int, tag
 	session := tr.data.DB.Context(ctx)
 
 	if len(tag.SlugName) > 0 {
+		// Both sides lowered, so the search is case-insensitive.
+		//
+		// This previously read LOWER(%s) formatted against the *search term*,
+		// which put the function name into the value: the query became
+		// slug_name LIKE '%LOWER(coco)%' and could never match. Only the
+		// display_name clause did anything, and that is case-sensitive on
+		// Postgres, so typing a tag in lower case -- which is how tags are
+		// written and therefore how anyone types them -- returned nothing at all
+		// and read as "no such tag".
+		search := searchTermForTag(tag.SlugName)
 		mainTagCond := builder.And(
 			builder.Or(
-				builder.Like{"slug_name", fmt.Sprintf("LOWER(%s)", tag.SlugName)},
-				builder.Like{"display_name", tag.SlugName},
+				builder.Like{"LOWER(slug_name)", search},
+				builder.Like{"LOWER(display_name)", search},
 			),
 			builder.Eq{"main_tag_id": 0},
 		)
@@ -292,4 +301,11 @@ func (tr *tagCommonRepo) UpdateTagsAttribute(ctx context.Context, tags []string,
 		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
 	}
 	return
+}
+
+// searchTermForTag normalises a tag search term. Lowering it here, and lowering
+// the columns in the query, is what makes the search case-insensitive: tags are
+// written in lower case, so that is how people type them.
+func searchTermForTag(term string) string {
+	return strings.ToLower(strings.TrimSpace(term))
 }

--- a/internal/repo/tag_common/tagsearch_test.go
+++ b/internal/repo/tag_common/tagsearch_test.go
@@ -1,0 +1,17 @@
+package tag_common
+
+import "testing"
+
+// The bug: the search term was formatted into LOWER(%s), which put the function
+// name into the value rather than applying it to the column, so the query became
+// slug_name LIKE '%LOWER(coco)%' and matched nothing. Only display_name did any
+// work, and that is case-sensitive on Postgres -- so typing a tag the way tags
+// are actually written returned "no such tag".
+func TestSearchTermIsLoweredNotWrapped(t *testing.T) {
+	for _, in := range []string{"Coco", "COCO", "coco"} {
+		got := searchTermForTag(in)
+		if got != "coco" {
+			t.Errorf("searchTermForTag(%q) = %q, want %q", in, got, "coco")
+		}
+	}
+}


### PR DESCRIPTION
## Proposed Changes

Tag search never matches on `slug_name`.

In `tagCommonRepo.GetTagPage`, the search term is formatted into `LOWER(%s)` and
passed as the **value** of the `LIKE`, so the function name ends up inside the
pattern rather than being applied to the column:

```go
builder.Like{"slug_name", fmt.Sprintf("LOWER(%s)", tag.SlugName)}
// -> slug_name LIKE '%LOWER(coco)%'
```

That can never match. Only the `display_name` clause does any work, and `LIKE`
is case-sensitive on PostgreSQL, so searching for a tag by the name it is
written in returns nothing:

```
GET /answer/api/v1/tags/page?slug_name=Coco   ->  ["coco"]
GET /answer/api/v1/tags/page?slug_name=coco   ->  []
```

Tags are lower case by convention, so lower case is what people type, and the
tag filter appears to report that no such tag exists.

  - Lower both the column and the term so the comparison is case-insensitive
  - Extract the term normalisation into `searchTermForTag` so the behaviour can
    be covered by a unit test without standing up a database
  - Add that test

Reproduced against 2.0.2 on PostgreSQL 18.