### PR TITLE
feat: add a banner area below the site header

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -11864,6 +11864,10 @@ const docTemplate = `{
         "schema.SiteCustomCssHTMLReq": {
             "type": "object",
             "properties": {
+                "custom_banner": {
+                    "type": "string",
+                    "maxLength": 65536
+                },
                 "custom_css": {
                     "type": "string",
                     "maxLength": 65536
@@ -11889,6 +11893,10 @@ const docTemplate = `{
         "schema.SiteCustomCssHTMLResp": {
             "type": "object",
             "properties": {
+                "custom_banner": {
+                    "type": "string",
+                    "maxLength": 65536
+                },
                 "custom_css": {
                     "type": "string",
                     "maxLength": 65536

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -11837,6 +11837,10 @@
         "schema.SiteCustomCssHTMLReq": {
             "type": "object",
             "properties": {
+                "custom_banner": {
+                    "type": "string",
+                    "maxLength": 65536
+                },
                 "custom_css": {
                     "type": "string",
                     "maxLength": 65536
@@ -11862,6 +11866,10 @@
         "schema.SiteCustomCssHTMLResp": {
             "type": "object",
             "properties": {
+                "custom_banner": {
+                    "type": "string",
+                    "maxLength": 65536
+                },
                 "custom_css": {
                     "type": "string",
                     "maxLength": 65536

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2353,6 +2353,9 @@ definitions:
     type: object
   schema.SiteCustomCssHTMLReq:
     properties:
+      custom_banner:
+        maxLength: 65536
+        type: string
       custom_css:
         maxLength: 65536
         type: string
@@ -2371,6 +2374,9 @@ definitions:
     type: object
   schema.SiteCustomCssHTMLResp:
     properties:
+      custom_banner:
+        maxLength: 65536
+        type: string
       custom_css:
         maxLength: 65536
         type: string

--- a/i18n/en_US.yaml
+++ b/i18n/en_US.yaml
@@ -2225,6 +2225,9 @@ ui:
       header:
         label: Header
         text: This will insert after &lt;body>
+      banner:
+        label: Banner
+        text: This will insert below the site header.
       footer:
         label: Footer
         text: This will insert before &lt;/body>.

--- a/internal/schema/siteinfo_schema.go
+++ b/internal/schema/siteinfo_schema.go
@@ -239,6 +239,7 @@ type SiteCustomCssHTMLReq struct {
 	CustomHead    string `validate:"omitempty,gt=0,lte=65536" json:"custom_head"`
 	CustomCss     string `validate:"omitempty,gt=0,lte=65536" json:"custom_css"`
 	CustomHeader  string `validate:"omitempty,gt=0,lte=65536" json:"custom_header"`
+	CustomBanner  string `validate:"omitempty,gt=0,lte=65536" json:"custom_banner"`
 	CustomFooter  string `validate:"omitempty,gt=0,lte=65536" json:"custom_footer"`
 	CustomSideBar string `validate:"omitempty,gt=0,lte=65536" json:"custom_sidebar"`
 }

--- a/ui/src/common/interface.ts
+++ b/ui/src/common/interface.ts
@@ -479,6 +479,7 @@ export interface AdminSettingsCustom {
   custom_css: string;
   custom_head: string;
   custom_header: string;
+  custom_banner: string;
   custom_footer: string;
   custom_sidebar: string;
 }

--- a/ui/src/components/CustomBanner/index.tsx
+++ b/ui/src/components/CustomBanner/index.tsx
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { memo, useEffect, useRef } from 'react';
+
+import { customizeStore } from '@/stores';
+
+/**
+ * Re-create every script node in the container, because the browser runs a
+ * script only when it is inserted as a node. dangerouslySetInnerHTML parses
+ * script tags without running them.
+ */
+const activateScriptNodes = (el: HTMLElement) => {
+  el.querySelectorAll('script').forEach((so) => {
+    const script = document.createElement('script');
+    // Wrap a classic script, to keep its declarations out of the page scope.
+    // Copy every other script as it is: a module has its own scope, and a data
+    // block such as application/ld+json must keep its content. The test matches
+    // the types the browser runs.
+    const type = so.getAttribute('type')?.trim().toLowerCase();
+    const isClassic =
+      !type || /^(text|application)\/(x-)?(java|ecma)script$/.test(type);
+    // The line breaks matter: a script that ends in a line comment would
+    // otherwise swallow the closing brace.
+    script.text = isClassic ? `(() => {\n${so.text}\n})();` : so.text;
+    for (let i = 0; i < so.attributes.length; i += 1) {
+      const attr = so.attributes[i];
+      script.setAttribute(attr.name, attr.value);
+    }
+    so.parentNode?.replaceChild(script, so);
+  });
+};
+
+const Index = () => {
+  const customBanner = customizeStore((state) => state.custom_banner);
+  const slotRef = useRef<HTMLDivElement>(null);
+  // The content whose scripts already ran. It stops the scripts from running
+  // again when React re-runs this effect for the same content.
+  const activatedBanner = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!customBanner) {
+      activatedBanner.current = null;
+      return;
+    }
+    if (!slotRef.current || customBanner === activatedBanner.current) {
+      return;
+    }
+    activatedBanner.current = customBanner;
+    activateScriptNodes(slotRef.current);
+  }, [customBanner]);
+
+  if (!customBanner) {
+    return null;
+  }
+
+  return (
+    <div
+      id="custom-banner-slot"
+      ref={slotRef}
+      dangerouslySetInnerHTML={{ __html: customBanner }}
+    />
+  );
+};
+
+export default memo(Index);

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -56,6 +56,7 @@ import QuestionList from './QuestionList';
 import HotQuestions from './HotQuestions';
 import HttpErrorContent from './HttpErrorContent';
 import CustomSidebar from './CustomSidebar';
+import CustomBanner from './CustomBanner';
 import ImgViewer from './ImgViewer';
 import SideNav from './SideNav';
 import PluginRender from './PluginRender';
@@ -111,6 +112,7 @@ export {
   HotQuestions,
   HttpErrorContent,
   CustomSidebar,
+  CustomBanner,
   ImgViewer,
   SideNav,
   PluginRender,

--- a/ui/src/pages/Admin/CssAndHtml/index.tsx
+++ b/ui/src/pages/Admin/CssAndHtml/index.tsx
@@ -50,6 +50,11 @@ const Index: FC = () => {
         title: t('header.label'),
         description: t('header.text'),
       },
+      custom_banner: {
+        type: 'string',
+        title: t('banner.label'),
+        description: t('banner.text'),
+      },
       custom_sidebar: {
         type: 'string',
         title: t('sidebar.label'),
@@ -84,6 +89,13 @@ const Index: FC = () => {
         className: ['small', 'font-monospace'],
       },
     },
+    custom_banner: {
+      'ui:widget': 'textarea',
+      'ui:options': {
+        rows: 10,
+        className: ['small', 'font-monospace'],
+      },
+    },
     custom_sidebar: {
       'ui:widget': 'textarea',
       'ui:options': {
@@ -108,6 +120,7 @@ const Index: FC = () => {
       custom_css: formData.custom_css.value,
       custom_head: formData.custom_head.value,
       custom_header: formData.custom_header.value,
+      custom_banner: formData.custom_banner.value,
       custom_sidebar: formData.custom_sidebar.value,
       custom_footer: formData.custom_footer.value,
     };
@@ -137,6 +150,7 @@ const Index: FC = () => {
         formMeta.custom_css.value = setting.custom_css;
         formMeta.custom_head.value = setting.custom_head;
         formMeta.custom_header.value = setting.custom_header;
+        formMeta.custom_banner.value = setting.custom_banner;
         formMeta.custom_sidebar.value = setting.custom_sidebar;
         formMeta.custom_footer.value = setting.custom_footer;
         setFormData(formMeta);

--- a/ui/src/pages/Layout/index.tsx
+++ b/ui/src/pages/Layout/index.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/stores';
 import {
   Header,
+  CustomBanner,
   Toast,
   Customize,
   CustomizeTheme,
@@ -211,6 +212,7 @@ const Layout: FC = () => {
           revalidateOnFocus: false,
         }}>
         <Header />
+        <CustomBanner />
         <div
           className={classnames(
             'position-relative page-wrap d-flex flex-column flex-fill',

--- a/ui/src/stores/customize.ts
+++ b/ui/src/stores/customize.ts
@@ -23,12 +23,14 @@ interface IType {
   custom_css: string;
   custom_head: string;
   custom_header: string;
+  custom_banner: string;
   custom_footer: string;
   custom_sidebar: string;
   update: (params: {
     custom_css?: string;
     custom_head?: string;
     custom_header?: string;
+    custom_banner?: string;
     custom_footer?: string;
     custom_sidebar?: string;
   }) => void;
@@ -38,6 +40,7 @@ const loginSetting = create<IType>((set) => ({
   custom_css: '',
   custom_head: '',
   custom_header: '',
+  custom_banner: '',
   custom_footer: '',
   custom_sidebar: '',
   update: (params) =>


### PR DESCRIPTION
## Proposed Changes

Answer has a **Header** area in Admin → CSS and HTML. The client writes its content at the top of `<body>`:

```js
const handleCustomHeader = (content) => {
  const el = document.body;
  renderCustomArea(el, CUSTOM_MARK_HEADER, 'afterbegin', content);
};
```

The server template writes it in the same place, before `<div id="root">`.

That position is above the nav bar and outside `#root`. The nav bar and the page are both inside `#root`, and the injected node is a sibling of `#root`. No stylesheet can move it below the nav. A banner under the site header is not possible today.

This PR **adds a new Banner area**. It does not move the Header area.

- `custom_banner` is a new field on `SiteCustomCssHTMLReq`, beside `custom_header` and `custom_sidebar`.
- `pages/Layout` renders `<CustomBanner />` below `<Header />`.
- Admin → CSS and HTML gets a **Banner** field, beside Head, Header, Footer and Sidebar.

`ui/template/header.html`, `internal/controller/template_controller.go` and `ui/src/components/Customize/index.tsx` are unchanged. The diff adds 136 lines and removes none.

## Answers to the review

**1. Breaking change.** Removed. The Header area keeps its position and its behaviour, so existing sites see no change. The banner is a separate optional field, and it stays empty until an admin fills it in. `CustomBanner` renders nothing while the field is empty.

**2. Scripts must run.** `CustomBanner` re-creates the script nodes after it renders the slot, so the browser runs them. It runs them one time for each value, and it tracks the value it activated. One difference from `ActivateScriptNodes`: it leaves a data block alone, such as a script with type `application/ld+json`. The browser never runs a data block, and the IIFE wrapper would corrupt its content.

**3. Head and footer refactor.** Reverted. `ui/src/components/Customize/index.tsx` matches `main` byte for byte, and the `meta[name="go-template"]` skip stays.

## Why the server template does not paint the banner

The first version of this PR painted the banner in `header.html` and read that markup back in the client. That cannot work, and it would have caused the same double execution described in point 3 above.

`ui/src/index.tsx` calls `ReactDOM.createRoot`, not `hydrateRoot`. `App` returns `<InitialLoadingPlaceholder />` on its first render, because `useMergeRoutes` starts with an empty route list and fills it in an effect. That placeholder is the first commit of the root, and `createRoot` clears the container on the first commit. So React empties `#root` before `Layout` renders at all. Any banner the server painted inside `#root` is already gone, and the browser has already run its scripts once while it parsed the document.

The banner is therefore client-rendered only, in the same way as `custom_sidebar` and `CustomSidebar`. `#spin-mask` covers the viewport until React mounts, so a reader never sees the difference.

## Checks

- `go build ./...` and `go vet` pass.
- `tsc --noEmit`, `eslint` and `prettier --check` pass on the changed files.
- Swagger docs regenerated with `swag` v1.16.3. The ASF licence headers on `docs/docs.go` and `docs/swagger.yaml` are kept.
