### PR TITLE
fix: use TagStatusDeleted instead of QuestionStatusDeleted in tag permission

### DIFF
--- a/internal/service/permission/tag_permission.go
+++ b/internal/service/permission/tag_permission.go
@@ -58,7 +58,7 @@ func GetTagPermission(ctx context.Context, status int, canEdit, canDelete, canMe
 		})
 	}
 
-	if canRecover && status == entity.QuestionStatusDeleted {
+	if canRecover && status == entity.TagStatusDeleted {
 		actions = append(actions, &schema.PermissionMemberAction{
 			Action: "undelete",
 			Name:   translator.Tr(lang, undeleteActionName),


### PR DESCRIPTION
## Summary

`GetTagPermission` compared the tag status against `entity.QuestionStatusDeleted` when deciding whether to expose the `undelete` action. The function operates on tag status, and the sibling `delete` / `merge` checks already use `entity.TagStatusDeleted`, so this aligns the `undelete` check with them.

Both constants are currently `10`, so there is no behavior change; this only removes a latent inconsistency that would break tag recovery if the values ever diverge.

## Changes

- `internal/service/permission/tag_permission.go`: `entity.QuestionStatusDeleted` → `entity.TagStatusDeleted`

## Testing

- `go build ./internal/service/permission/` passes