### PR TITLE
fix(ui): allow uppercase letters in username on profile settings

### DIFF
--- a/ui/src/pages/Users/Settings/Profile/index.tsx
+++ b/ui/src/pages/Users/Settings/Profile/index.tsx
@@ -177,7 +177,7 @@ const Index: React.FC = () => {
         isInvalid: true,
         errorMsg: t('username.msg_range'),
       };
-    } else if (/[^a-z0-9\-._]/.test(username.value)) {
+    } else if (/[^a-z0-9\-._]/i.test(username.value)) {
       bol = false;
       formData.username = {
         value: username.value,


### PR DESCRIPTION
Users whose username contains an uppercase letter cannot save their profile at all — not even when they leave the username untouched, because the whole form is validated on submit.

The check in profile settings is the only one of four that rejects uppercase:

| where | pattern | uppercase |
|---|---|---|
| `ui/src/pages/Users/Register/components/SignUpForm/index.tsx` | `/^[\w.-\s]{2,30}$/` | allowed |
| `ui/src/pages/Install/components/FourthStep/index.tsx` | `/^[\w.-\s]{2,30}$/` | allowed |
| `pkg/checker/username.go` | `^[\w.\- ]{2,30}$` | allowed |
| `ui/src/pages/Users/Settings/Profile/index.tsx` | `/[^a-z0-9\-._]/` | **rejected** |

So one can sign up as `MaxMustermann`, and from then on the profile page is locked. The error message points at the username field without saying why a name the server itself issued is suddenly invalid.

I ran into this migrating a 26-year-old forum to Answer: 3368 of 5479 accounts carry uppercase letters in names that have been in use for two decades.

## Proposed Changes

  - add the ignore-case flag to the username check in profile settings, bringing it in line with registration, installation and the server
  - permits nothing the server would reject; no data or API behaviour changes

An alternative would be to reuse the exact pattern from `SignUpForm`, but that also allows spaces, which felt like a larger change than this fix needs. Happy to switch if you prefer the patterns to be literally identical.