### PR TITLE
fix(ui): request answers page by page instead of 999 at once

### DIFF
--- a/ui/src/pages/Questions/Detail/index.tsx
+++ b/ui/src/pages/Questions/Detail/index.tsx
@@ -52,6 +52,10 @@ import {
 
 import './index.scss';
 
+// Answers are paginated; the request, the page count and the pagination
+// control all have to agree on this number.
+const ANSWER_PAGE_SIZE = 15;
+
 const Index = () => {
   const navigate = useNavigate();
   const { t } = useTranslation('translation');
@@ -101,8 +105,8 @@ const Index = () => {
     const res = await getAnswers({
       order: order === 'updated' || order === 'created' ? order : 'default',
       question_id: qid,
-      page: 1,
-      page_size: 999,
+      page: page || 1,
+      page_size: ANSWER_PAGE_SIZE,
     });
 
     if (res) {
@@ -121,7 +125,7 @@ const Index = () => {
         return v;
       });
 
-      setAnswers({ ...res, count: res.list.length });
+      setAnswers({ ...res, count: res.count });
       if (page > 0 || order) {
         // scroll into view;
         const element = document.getElementById('answerHeader');
@@ -275,11 +279,11 @@ const Index = () => {
           </>
         )}
 
-        {!isLoading && Math.ceil(answers.count / 15) > 1 && (
+        {!isLoading && Math.ceil(answers.count / ANSWER_PAGE_SIZE) > 1 && (
           <div className="d-flex justify-content-center answer-item pt-4">
             <Pagination
               currentPage={Number(page || 1)}
-              pageSize={15}
+              pageSize={ANSWER_PAGE_SIZE}
               totalSize={answers?.count || 0}
             />
           </div>


### PR DESCRIPTION
The question page already has everything it needs to paginate: the page number comes from the URL, a `useEffect` reloads when it changes, and a `Pagination` control is rendered. Only the request ignores all of it:

```ts
const res = await getAnswers({
  question_id: qid,
  page: 1,
  page_size: 999,
});
```

**Answers past the 999th are unreachable.** The list never contains them, and since the displayed count is the length of that list, the heading claims the question has exactly 999 answers. In the forum I maintain two threads are above that limit — 13368 and 10110 answers — so roughly 22000 posts could not be reached through the UI at all.

**Long questions are slow.** Measured on a question with 999 answers:

| | time to first answer visible |
|---|---|
| ordinary question | 0.2 s |
| 999 answers | 19 s |

The browser parses and hydrates a thousand posts in order to show fifteen.

## Proposed Changes

  - request `page` from the URL and `ANSWER_PAGE_SIZE` answers per page
  - take the total from `res.count` instead of the length of the current page, so the heading and the page count stay correct
  - name the page size once instead of repeating `15` in three places

## One behavioural note

The list is filtered client-side to hide deleted answers that only their author and admins may see. With every answer loaded, counting the filtered list happened to give an exact total. Now the total comes from the server and can be off by the number of deleted answers on the current page. Filtering those server-side would remove the discrepancy entirely, but that looked out of scope for this fix.

Verified with `prettier --check` against the projects config.