### PR TITLE
fix(controller): cap answers rendered into the server-side page

### DIFF
--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -52,6 +52,17 @@ import (
 	"github.com/segmentfault/pacman/log"
 )
 
+// maxTemplateAnswerPageSize caps how many answers are rendered into the
+// server-side page. The template shows every answer it is given and has no
+// pagination, so this value is also the number of answers a crawler sees.
+//
+// It exists because the previous value of 999 made long questions unusable:
+// the server fetches the answers, then the comments for every one of them,
+// and the browser has to parse and hydrate the result. On a question with
+// 999 answers that took 2.6s on the server and 23.5s until the first answer
+// was visible, against 0.2s for an ordinary question.
+const maxTemplateAnswerPageSize = 100
+
 var SiteUrl = ""
 
 type TemplateController struct {
@@ -345,7 +356,7 @@ func (tc *TemplateController) QuestionInfo(ctx *gin.Context) {
 		QuestionID: id,
 		Order:      "",
 		Page:       1,
-		PageSize:   999,
+		PageSize:   maxTemplateAnswerPageSize,
 		UserID:     "",
 	}
 	answers, answerCount, err := tc.templateRenderController.AnswerList(ctx, answerReq)


### PR DESCRIPTION
The question template fetches 999 answers, then the comments for all of them, regardless of how many the page will show. The value is a literal in the controller, so there is no way to lower it:

```go
answerReq := &schema.AnswerListReq{
    QuestionID: id,
    Page:       1,
    PageSize:   999,
}
```

Measured on a question with 999 answers, against 0.2 s for an ordinary one:

| | |
|---|---|
| HTML ready on the server | 2.6 s |
| first answer visible in the browser | 23.5 s |

Most of that is spent parsing 878 KB of HTML and hydrating a thousand posts.

## Proposed Changes

  - replace the literal with a named constant of 100 and document what the number is for

## This is a mitigation, not a fix

The template renders whatever it is given and has no pagination, so any value here trades page weight against how much of a long question a crawler gets to see. 100 is a compromise: of 7382 questions in my forum only 30 have more than a hundred answers, so for all the others nothing changes at all.

The real fix is to paginate the template page the way the question list already does — bind the page from the query and render `ui/template/page.html`, which exists and is used elsewhere. That is a larger change touching both the controller and the template, so I did not want to submit it unasked. Happy to prepare it as a follow-up if you prefer that route.

Related: #1573 does the same for the client-side request.