### PR TITLE
fix: allow non-Latin characters in display names

### DIFF
--- a/internal/service/user_common/user.go
+++ b/internal/service/user_common/user.go
@@ -21,6 +21,7 @@ package usercommon
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/apache/answer/internal/base/constant"
@@ -35,6 +36,7 @@ import (
 	"github.com/apache/answer/pkg/checker"
 	"github.com/apache/answer/pkg/random"
 	"github.com/mozillazg/go-pinyin"
+	"github.com/mozillazg/go-unidecode"
 	"github.com/segmentfault/pacman/errors"
 	"github.com/segmentfault/pacman/log"
 )
@@ -190,6 +192,10 @@ func (us *UserCommon) FormatUserBasicInfo(ctx context.Context, userInfo *entity.
 	return userBasicInfo
 }
 
+// usernameDisallowed matches everything checker.IsInvalidUsername rejects.
+// Kept in sync with pkg/checker/username.go.
+var usernameDisallowed = regexp.MustCompile(`[^\w.\- ]`)
+
 // MakeUsername
 // Generate a unique Username based on the displayName
 func (us *UserCommon) MakeUsername(ctx context.Context, displayName string) (username string, err error) {
@@ -197,6 +203,17 @@ func (us *UserCommon) MakeUsername(ctx context.Context, displayName string) (use
 	if has := checker.IsChinese(displayName); has {
 		displayName = strings.Join(pinyin.LazyConvert(displayName, nil), "")
 	}
+
+	// Other non-Latin characters, such as German umlauts or accented
+	// letters, are transliterated the same way question URLs are (see
+	// pkg/htmltext). Without this, a display name like "Jürgen Müller"
+	// would produce an invalid username and registration would fail.
+	displayName = unidecode.Unidecode(displayName)
+
+	// Transliteration can emit characters a username may not contain:
+	// "Ольга" becomes "Ol'ga", for example. Drop those, so the result
+	// still satisfies checker.IsInvalidUsername below.
+	displayName = usernameDisallowed.ReplaceAllString(displayName, "")
 
 	username = strings.ReplaceAll(displayName, " ", "-")
 	username = strings.ToLower(username)

--- a/ui/src/pages/Users/Register/components/SignUpForm/index.tsx
+++ b/ui/src/pages/Users/Register/components/SignUpForm/index.tsx
@@ -57,7 +57,7 @@ const Index: React.FC<Props> = ({ callback }) => {
   });
 
   const emailCaptcha = useCaptchaPlugin('email');
-  const nameRegex = /^[\w.-\s]{2,30}$/;
+  const nameRegex = /^[\p{L}\p{N}._\s-]{2,30}$/u;
 
   const handleChange = (params: FormDataType) => {
     setFormData({ ...formData, ...params });


### PR DESCRIPTION
### Problem

Registering with a display name such as `Jürgen Müller` fails. The form
shows *"Erlaubt sind a-z, 0-9, - . _"* and the request never succeeds.

Two checks reject it, both relying on `\w`, which means `[A-Za-z0-9_]` in
JavaScript as well as in Go:

| | |
|---|---|
| `ui/src/pages/Users/Register/components/SignUpForm/index.tsx:60` | `const nameRegex = /^[\w.-\s]{2,30}$/` |
| `pkg/checker/username.go:25` | ``usernameReg = `^[\w.\- ]{2,30}$` `` |

This affects every language except English — German umlauts, accented
letters in French, Spanish or Portuguese, Cyrillic, Greek. Answer ships
translations for over 40 languages, but a user whose name contains a
letter outside ASCII cannot register under it.

### Why the check exists

The second check is not really about the display name. `MakeUsername`
derives the username from it, and the username appears in a profile URL,
so restricting it makes sense. The restriction is just applied one step
too early — to the display name rather than to the derived username.

### Approach

Answer already solves exactly this problem elsewhere: question URLs are
transliterated in `pkg/htmltext` via `unidecode.Unidecode`, and
`MakeUsername` already handles Chinese through `pinyin`. This change
carries that idea through.

1. Transliterate the display name before deriving the username, using
   `github.com/mozillazg/go-unidecode` — already a direct dependency.
2. Drop what transliteration may leave behind: `Ольга` becomes `Ol'ga`,
   and an apostrophe is not a valid username character.
3. Widen the front-end check to Unicode letters and digits (`\p{L}`,
   `\p{N}`).

The display name keeps its original spelling. Only the derived username
is transliterated:

```
Jürgen Müller  ->  jurgen-muller
José García    ->  jose-garcia
Ольга          ->  olga
Ελένη          ->  elene
Straße         ->  strasse
Kerstin Harms  ->  kerstin-harms   (unchanged)
```

Chinese input is unaffected — `pinyin` still runs first, and its output
is already ASCII.

### Notes

- No new dependency.
- `gofmt` clean.
- Found while migrating a 26-year-old German optometry forum with 5,479
  member accounts to Answer; roughly one in twenty names carries a
  character outside ASCII.