### PR TITLE
fix: parse built asset tags from the document and render every entry stylesheet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/image v0.20.0
+	golang.org/x/net v0.56.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.39.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
@@ -170,7 +171,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.10.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -20,6 +20,7 @@
 package controller
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -50,6 +51,7 @@ import (
 	"github.com/apache/answer/ui"
 	"github.com/gin-gonic/gin"
 	"github.com/segmentfault/pacman/log"
+	"golang.org/x/net/html"
 )
 
 var SiteUrl = ""
@@ -88,19 +90,59 @@ func GetStyle() (script []string, css string) {
 	if err != nil {
 		return
 	}
-	scriptRegexp := regexp.MustCompile(`<script defer="defer" src="([^"]*)"></script>`)
-	scriptData := scriptRegexp.FindAllStringSubmatch(string(file), -1)
-	for _, s := range scriptData {
-		if len(s) == 2 {
-			script = append(script, s[1])
-		}
+
+	// The frontend build tool controls attribute order, attribute set (e.g.
+	// module vs classic scripts), and quoting for the emitted tags, and that
+	// shape has already changed once. Walk the parsed DOM instead of matching
+	// a literal tag shape so the next bundler change fails a test instead of
+	// silently shipping pages with no JS or CSS.
+	doc, err := html.Parse(bytes.NewReader(file))
+	if err != nil {
+		return
 	}
 
-	cssRegexp := regexp.MustCompile(`<link href="(.*)" rel="stylesheet">`)
-	cssListData := cssRegexp.FindStringSubmatch(string(file))
-	if len(cssListData) == 2 {
-		css = cssListData[1]
+	attr := func(n *html.Node, key string) (string, bool) {
+		for _, a := range n.Attr {
+			if a.Key == key {
+				return a.Val, true
+			}
+		}
+		return "", false
 	}
+	isStylesheet := func(n *html.Node) bool {
+		rel, ok := attr(n, "rel")
+		if !ok {
+			return false
+		}
+		for _, tok := range strings.Fields(rel) {
+			if strings.EqualFold(tok, "stylesheet") {
+				return true
+			}
+		}
+		return false
+	}
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "script":
+				if src, ok := attr(n, "src"); ok && src != "" {
+					script = append(script, src)
+				}
+			case "link":
+				if css == "" && isStylesheet(n) {
+					if href, ok := attr(n, "href"); ok && href != "" {
+						css = href
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
 	return
 }
 func (tc *TemplateController) SiteInfo(ctx *gin.Context) *schema.TemplateSiteInfoResp {

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -57,8 +57,11 @@ import (
 var SiteUrl = ""
 
 type TemplateController struct {
-	scriptPath               []string
-	cssPath                  string
+	scriptPath []string
+	// cssPath lists every stylesheet the frontend build emits, in document
+	// order; a build that emits more than one entry stylesheet needs all of
+	// them, not just the first, or server-rendered pages come back unstyled.
+	cssPath                  []string
 	templateRenderController *templaterender.TemplateRenderController
 	siteInfoService          siteinfo_common.SiteInfoCommonService
 	eventQueueService        eventqueue.Service
@@ -85,7 +88,7 @@ func NewTemplateController(
 		questionService:          questionService,
 	}
 }
-func GetStyle() (script []string, css string) {
+func GetStyle() (script []string, css []string) {
 	file, err := ui.Build.ReadFile("build/index.html")
 	if err != nil {
 		return
@@ -131,9 +134,9 @@ func GetStyle() (script []string, css string) {
 					script = append(script, src)
 				}
 			case "link":
-				if css == "" && isStylesheet(n) {
+				if isStylesheet(n) {
 					if href, ok := attr(n, "href"); ok && href != "" {
-						css = href
+						css = append(css, href)
 					}
 				}
 			}
@@ -602,7 +605,7 @@ func (tc *TemplateController) Page404(ctx *gin.Context) {
 
 func (tc *TemplateController) html(ctx *gin.Context, code int, tpl string, siteInfo *schema.TemplateSiteInfoResp, data gin.H) {
 	prefix := ""
-	cssPath := ""
+	cssPath := make([]string, len(tc.cssPath))
 	scriptPath := make([]string, len(tc.scriptPath))
 
 	_ = plugin.CallCDN(func(fn plugin.CDN) error {
@@ -614,7 +617,9 @@ func (tc *TemplateController) html(ctx *gin.Context, code int, tpl string, siteI
 		if prefix[len(prefix)-1:] == "/" {
 			prefix = strings.TrimSuffix(prefix, "/")
 		}
-		cssPath = prefix + tc.cssPath
+		for i, path := range tc.cssPath {
+			cssPath[i] = prefix + path
+		}
 		for i, path := range tc.scriptPath {
 			scriptPath[i] = prefix + path
 		}

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -117,7 +117,7 @@ func GetStyle() (script []string, css []string) {
 		if !ok {
 			return false
 		}
-		for _, tok := range strings.Fields(rel) {
+		for tok := range strings.FieldsSeq(rel) {
 			if strings.EqualFold(tok, "stylesheet") {
 				return true
 			}

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -94,11 +94,11 @@ func GetStyle() (script []string, css []string) {
 		return
 	}
 
-	// The frontend build tool controls attribute order, attribute set (e.g.
-	// module vs classic scripts), and quoting for the emitted tags, and that
-	// shape has already changed once. Walk the parsed DOM instead of matching
-	// a literal tag shape so the next bundler change fails a test instead of
-	// silently shipping pages with no JS or CSS.
+	// Script and stylesheet tags are read from the parsed document, so
+	// attribute order, attribute set (module vs classic scripts), and
+	// quoting do not matter. That shape has already changed once; a
+	// bundler change that breaks it now fails the guarding test instead
+	// of silently shipping pages with no JS or CSS.
 	doc, err := html.Parse(bytes.NewReader(file))
 	if err != nil {
 		return

--- a/internal/controller/template_controller_test.go
+++ b/internal/controller/template_controller_test.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/apache/answer/ui"
+	"github.com/stretchr/testify/require"
+)
+
+// GetStyle scrapes the script and stylesheet paths out of the built
+// index.html and every server-rendered page reuses them. The scrape is
+// coupled to the exact attribute order and attribute set that the frontend
+// build tool writes into those tags, and nothing in the system reports a
+// mismatch: the frontend build still succeeds, the dev server still works,
+// the binary still compiles, and the server-rendered pages simply come back
+// with no script tags and no stylesheet.
+//
+// Assert the coupling directly so a change to the emitted tag shape fails
+// here instead of shipping.
+func TestGetStyleResolvesBuiltAssets(t *testing.T) {
+	const builtIndexPath = "build/index.html"
+
+	if _, err := ui.Build.ReadFile(builtIndexPath); err != nil {
+		t.Skipf("no frontend build embedded at %s; build the frontend and re-run: %v", builtIndexPath, err)
+	}
+
+	scripts, css := GetStyle()
+
+	require.NotEmpty(t, scripts,
+		"no script sources parsed out of %s; server-rendered pages would load without any JavaScript", builtIndexPath)
+	for i, src := range scripts {
+		require.NotEmpty(t, src, "script source %d parsed out of %s is empty", i, builtIndexPath)
+	}
+
+	require.NotEmpty(t, css,
+		"no stylesheet href parsed out of %s; server-rendered pages would load unstyled", builtIndexPath)
+}

--- a/internal/controller/template_controller_test.go
+++ b/internal/controller/template_controller_test.go
@@ -20,6 +20,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/apache/answer/ui"
@@ -39,7 +40,8 @@ import (
 func TestGetStyleResolvesBuiltAssets(t *testing.T) {
 	const builtIndexPath = "build/index.html"
 
-	if _, err := ui.Build.ReadFile(builtIndexPath); err != nil {
+	raw, err := ui.Build.ReadFile(builtIndexPath)
+	if err != nil {
 		t.Skipf("no frontend build embedded at %s; build the frontend and re-run: %v", builtIndexPath, err)
 	}
 
@@ -57,4 +59,20 @@ func TestGetStyleResolvesBuiltAssets(t *testing.T) {
 		require.NotEmpty(t, href,
 			"stylesheet href %d parsed out of %s is empty; server-rendered pages would load unstyled", i, builtIndexPath)
 	}
+
+	// Finding every stylesheet matters as much as finding one. The build emits
+	// more than a single entry stylesheet, and a parser that stopped at the
+	// first one would still satisfy every assertion above while half the page's
+	// CSS silently stopped loading. That regression has happened once already.
+	//
+	// Count them again by a deliberately different and cruder method than the
+	// parser uses, so the two have to agree. It is a lower bound: a build that
+	// quotes attributes differently drives this to zero and the comparison
+	// simply stops constraining, which is why it supplements the assertions
+	// above rather than replacing them.
+	declared := strings.Count(string(raw), `rel="stylesheet"`)
+	require.GreaterOrEqual(t, len(css), declared,
+		"%s declares at least %d stylesheets but only %d were parsed out of it; "+
+			"server-rendered pages would load missing part of their CSS",
+		builtIndexPath, declared, len(css))
 }

--- a/internal/controller/template_controller_test.go
+++ b/internal/controller/template_controller_test.go
@@ -53,4 +53,8 @@ func TestGetStyleResolvesBuiltAssets(t *testing.T) {
 
 	require.NotEmpty(t, css,
 		"no stylesheet href parsed out of %s; server-rendered pages would load unstyled", builtIndexPath)
+	for i, href := range css {
+		require.NotEmpty(t, href,
+			"stylesheet href %d parsed out of %s is empty; server-rendered pages would load unstyled", i, builtIndexPath)
+	}
 }

--- a/ui/template/header.html
+++ b/ui/template/header.html
@@ -34,7 +34,9 @@
     <link rel="canonical" href="{{.siteinfo.Canonical}}" />
     <link rel="manifest" href="{{$.baseURL}}/manifest.json" />
     <link rel="search" type="application/opensearchdescription+xml" href="{{$.baseURL}}/opensearch.xml" title="{{.siteinfo.General.Name}}" />
-    <link href="{{.cssPath}}" rel="stylesheet" />
+    {{range $path := .cssPath}}
+    <link href="{{$path}}" rel="stylesheet" />
+    {{end}}
     <link href="{{$.baseURL}}/custom.css" rel="stylesheet" />
     <link
       rel="icon"


### PR DESCRIPTION
Fixes #1579. Part of #1578. Step 1 of 3; lands while Create React App still builds, and step 2 (the Vite cutover) depends on it.

Three parts of the Go side had one bundler's output format encoded into them. This PR removes two of them ahead of the toolchain change; the third, the classic script tag in `header.html`, is the one line step 2 flips together with the build that emits modules, so the cutover itself stays a frontend-only diff plus that line.

**`GetStyle()` matched a literal tag shape.** It scraped `index.html` with regexes requiring classic scripts with `defer` first and stylesheet links with `href` before `rel`. Any other shape returned nothing, and server-rendered pages would load with no JavaScript and no stylesheet while every build step still reported success. The tags are now read from the parsed document (`golang.org/x/net/html`, already in the module graph and promoted from indirect to direct in `go.mod`), so attribute order, attribute set and quoting no longer matter, and the next bundler change cannot reintroduce this. The parser accepts any shape as long as the tag is present; what it guards is a missing script or stylesheet tag.

**`GetStyle()` returned a single stylesheet.** The current build emits exactly one entry stylesheet; the Vite build emits two, so pages would load partially unstyled. It is now a list, mirroring how script paths were already collected and prefixed, and `header.html` ranges over it. With today's build that is a list of one, and the rendered page is unchanged.

**`header.html` keeps its classic script tag.** `<script defer="defer" src="{{$path}}">` is untouched here on purpose; it becomes a module tag in step 2, together with the build that emits modules.

**Test.** `TestGetStyleResolvesBuiltAssets` in `internal/controller/template_controller_test.go` calls the real `GetStyle()` against the real embedded build and requires at least one script source and every declared stylesheet to come back. It skips when no frontend build is embedded, which is a constraint for anyone wiring CI later: a bare `go test ./...` reports ok while asserting nothing about the asset paths unless the frontend was built first. The self-check harness that rewrites the built `index.html` into unparseable shapes and asserts the test fails on each follows in step 3.

Agentic tooling did the mechanical work in this series; every change was reviewed by a human before being committed.

### Verification

On `dev` at `2c0ced32` plus these commits, with the current toolchain: `pnpm install --frozen-lockfile` and `pnpm build` (react-scripts) complete; `go build ./...` and `go vet ./...` pass; `TestGetStyleResolvesBuiltAssets` passes against the Create React App output (`--- PASS`, not skipped), and as a negative control the same test fails when the built `index.html` is rewritten without a script `src`, then passes again once the original is restored. The built index.html at that point carries eight classic `<script defer="defer" src="/static/js/...">` tags, one inline script and one stylesheet link, and the parser returns all eight sources and the one stylesheet.

The commits carry `(cherry picked from commit ...)` lines pointing at the branch behind #1567, where this change was first reviewed.
