### PR TITLE
fix(template): repair avatar images in the server-rendered question list

### DIFF
--- a/ui/template/question.html
+++ b/ui/template/question.html
@@ -36,7 +36,7 @@
               <div class="d-flex flex-wrap text-secondary small mb-12">
                 <div class="d-flex align-items-center  text-secondary me-1">
                   <a href="{{$.baseURL}}/users/{{.Operator.Username}}">
-                    <img src="{{$.baseURL}}/users/{{.Operator.Avatar}}" width="24px" height="24px" class="rounded-circle me-1" alt="shuai" data-processed="true">
+                    <img src="{{.Operator.Avatar}}" width="24" height="24" class="rounded-circle me-1" alt="{{.Operator.DisplayName}}" data-processed="true">
                     <span class="me-1 name-ellipsis" style="max-width: 300px;">{{.Operator.DisplayName}}</span>
                   </a>
                   <span class="fw-bold" title="Reputation">{{.Operator.Rank}}</span>


### PR DESCRIPTION
The avatar in `ui/template/question.html` is built as:

```html
<img src="{{$.baseURL}}/users/{{.Operator.Avatar}}" width="24px" height="24px"
     class="rounded-circle me-1" alt="shuai" data-processed="true">
```

`.Operator.Avatar` already holds the full avatar reference, so prefixing it with
`/users/` yields an address that cannot resolve. Every question in the
server-rendered list renders a broken image — ten of them on a default page.
This is also the only template that adds the prefix; the four other places that
show an avatar use the value directly:

| file | line |
|---|---|
| `ui/template/question-detail.html` | `src="{{.detail.UserInfo.Avatar}}"` |
| `ui/template/question-detail.html` | `src="{{.UserInfo.Avatar}}"` (twice) |
| `ui/template/homepage.html` | `src="{{.userinfo.Avatar}}"` |

Two further defects sit in the same tag:

- **`alt="shuai"`** is placeholder text left over from a copied DOM. A screen
  reader announces it once per avatar. It now carries the display name of the
  person who asked.
- **`width="24px"` / `height="24px"`** are invalid — HTML dimension attributes
  take a number without a unit. Browsers discard them and fall back to the
  intrinsic size of the image, which makes every row of the list taller than the
  interface renders it.

### How it was found

Building a site that shows the server-rendered pages to visitors rather than
only to crawlers. All three defects are invisible as long as the React
interface replaces the markup a moment later.

### Note

Where a user has no avatar set, `.Operator.Avatar` is empty and `src=""` remains
— the interface substitutes `default-avatar.svg` in that case, the templates do
not. That is a separate question and left untouched here to keep this change to
the defect described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)