### PR TITLE
fix(template): translate the search placeholder in the server-rendered header

### DIFF
--- a/ui/template/header.html
+++ b/ui/template/header.html
@@ -170,7 +170,7 @@
           <div class="d-none d-xl-block flex-grow-1 me-auto">
             <div class="d-none d-xl-block ps-0 col-lg-8">
               <form action="/search" class="w-100 maxw-400">
-                <input placeholder="Search" name="q" type="search" class="placeholder-search form-control" value="">
+                <input placeholder="{{translator $.language "ui.header.search.placeholder"}}" name="q" type="search" class="placeholder-search form-control" value="">
               </form>
             </div>
             <!-- <div class="xl-none mt-3 pb-1 nav-item">


### PR DESCRIPTION
`ui/template/header.html` writes the placeholder literally:

```html
<input placeholder="Search" name="q" type="search" class="placeholder-search form-control" value="">
```

Every other string in that file goes through `translator`, and the key for this
one already exists — `ui.header.search.placeholder`, present in all 45 language
files under `i18n/`. The React interface uses it; only the template does not.

The result is one English word in the middle of an otherwise translated page.
Two audiences see it: readers, until the interface takes over, and search
engines, which see nothing else.

```html
<input placeholder="{{translator $.language "ui.header.search.placeholder"}}" …>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)