### PR TITLE
fix(template): show tag display names instead of their slugs

### DIFF
--- a/ui/template/question-detail.html
+++ b/ui/template/question-detail.html
@@ -68,7 +68,7 @@
             {{range .detail.Tags}}
             <a href="{{$.baseURL}}/tags/{{.SlugName}}"
                 class="badge-tag rounded-1 {{if .Reserved}}badge-tag-reserved{{end}} {{if .Recommend}}badge-tag-required{{end}} m-1">
-              <span class="">{{.SlugName}}</span>
+              <span class="">{{.DisplayName}}</span>
             </a>
             {{end}}
           </div>

--- a/ui/template/question.html
+++ b/ui/template/question.html
@@ -75,7 +75,7 @@
                 <a
                   href="{{$.baseURL}}/tags/{{.SlugName}}"
                   class="badge-tag rounded-1 {{if .Reserved}}badge-tag-reserved{{end}} {{if .Recommend}}badge-tag-required{{end}} me-1">
-                  <span class="">{{.SlugName}}</span>
+                  <span class="">{{.DisplayName}}</span>
                 </a>
                 {{end}}
               </div>

--- a/ui/template/tag-detail.html
+++ b/ui/template/tag-detail.html
@@ -25,7 +25,7 @@
       <div class="page-main flex-auto col">
         <div class="tag-box mb-5">
           <h3 class="mb-3">
-            <a class="link-dark" href="{{$.baseURL}}/tags/{{$.tag.SlugName}}">{{$.tag.SlugName}}</a>
+            <a class="link-dark" href="{{$.baseURL}}/tags/{{$.tag.SlugName}}">{{$.tag.DisplayName}}</a>
           </h3>
           <p class="text-break">{{formatLinkNofollow $.tag.ParsedText}}</p>
         </div>
@@ -80,7 +80,7 @@
                 {{range .Tags }}
                 <a href="{{$.baseURL}}/tags/{{.SlugName}}"
                   class="badge-tag rounded-1 {{if .Reserved}}badge-tag-reserved{{end}} {{if .Recommend}}badge-tag-required{{end}} m-1">
-                  <span class="">{{.SlugName}}</span>
+                  <span class="">{{.DisplayName}}</span>
                 </a>
                 {{end}}
               </div>

--- a/ui/template/tags.html
+++ b/ui/template/tags.html
@@ -54,7 +54,7 @@
             <div class="h-100 card">
               <div class="d-flex flex-column align-items-start card-body">
                 <a href="{{$.baseURL}}/tags/{{.SlugName}}" class="badge-tag rounded-1 mb-3"><span
-                    class="">{{.SlugName}}</span></a>
+                    class="">{{.DisplayName}}</span></a>
                 <div class="small flex-fill text-break text-wrap text-truncate-3 reset-p mb-3">  {{formatLinkNofollow .ParsedText}}
                 </div>
                 <div class="d-flex align-items-center">


### PR DESCRIPTION
The server-rendered templates print a tag's **slug** where the React interface
prints its **display name**:

```html
<a href="{{$.baseURL}}/tags/{{.SlugName}}" class="badge-tag …">
  <span class="">{{.SlugName}}</span>
</a>
```

For Latin-script tags this is a matter of case — `binokularsehen` against
`Binokularsehen`. For everything else it is worse: Answer transliterates slugs
(hence `mozillazg-go-unidecode` among the dependencies), so a tag named 眼镜
renders as `yan-jing` on every server-rendered page.

Two audiences are affected: search engines, which see nothing else, and readers,
until the interface takes over.

Changed in four templates — `question.html`, `question-detail.html`,
`tag-detail.html` (the heading and the list) and `tags.html`. **Only the text**;
every `href` goes on using the slug.

### Note

`display_name` is `not null default ` in `entity.Tag`, so a tag with an empty
display name would now render as an empty badge. The API requires the field when
a tag is created, so this should not occur — but if you would rather have a
fallback, `{{if .DisplayName}}…{{else}}{{.SlugName}}{{end}}` is a one-line
change and I am happy to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)