### PR TITLE
fix(ui): give the pages a heading hierarchy

### DIFF
--- a/ui/src/components/QuestionList/index.tsx
+++ b/ui/src/components/QuestionList/index.tsx
@@ -100,13 +100,21 @@ const QuestionList: FC<Props> = ({
   return (
     <div>
       <div className="mb-3 d-flex flex-wrap justify-content-between">
-        <h5 className="fs-5 text-nowrap mb-3 mb-md-0">
-          {source === 'questions'
-            ? t('all_questions')
-            : source === 'linked'
+        {/* `h1` where this heading is the page's own — the question list at
+            /questions has no other. Everywhere else the page brings its own
+            `h1` and this one sits below it. `fs-5` keeps the size it had as
+            an `h5`. */}
+        {source === 'questions' ? (
+          <h1 className="fs-5 text-nowrap mb-3 mb-md-0">
+            {t('all_questions')}
+          </h1>
+        ) : (
+          <h2 className="fs-5 text-nowrap mb-3 mb-md-0">
+            {source === 'linked'
               ? t('x_posts', { count })
               : t('x_questions', { count })}
-        </h5>
+          </h2>
+        )}
         <div className="d-flex flex-wrap">
           <QueryGroup
             data={orderKeys}
@@ -167,7 +175,9 @@ const QuestionList: FC<Props> = ({
                       className="text-secondary ms-1 flex-shrink-0"
                     />
                   </div>
-                  <h5 className="text-wrap text-break">
+                  {/* One level below the list's own heading, not the same
+                      one it used to share with it. `fs-5` keeps the size. */}
+                  <h3 className="fs-5 text-wrap text-break">
                     <NavLink
                       className="link-dark d-block"
                       onClick={(e) => e.stopPropagation()}
@@ -175,7 +185,7 @@ const QuestionList: FC<Props> = ({
                       {li.title}
                       {li.status === 2 ? ` [${t('closed')}]` : ''}
                     </NavLink>
-                  </h5>
+                  </h3>
                   {viewType === 'card' && (
                     <div className="text-truncate-2 mb-2">
                       <NavLink

--- a/ui/src/pages/Badges/index.tsx
+++ b/ui/src/pages/Badges/index.tsx
@@ -35,11 +35,11 @@ const Index = () => {
 
   return (
     <div className="pt-4 mb-5">
-      <h3 className="mb-4">{t('title')}</h3>
+      <h1 className="fs-3 mb-4">{t('title')}</h1>
       {badgesList?.map((item) => {
         return (
           <div key={item.group_name} className="mb-4">
-            <h5 className="mb-4">{item.group_name}</h5>
+            <h2 className="fs-5 mb-4">{item.group_name}</h2>
             <Row>
               {item.badges?.map((badge) => {
                 return (

--- a/ui/src/pages/Questions/Linked/index.tsx
+++ b/ui/src/pages/Questions/Linked/index.tsx
@@ -81,7 +81,7 @@ const LinkedQuestions: FC = () => {
   return (
     <Row className="pt-4 mb-5">
       <Col className="page-main flex-auto">
-        <h3 className="mb-3">{t('title')}</h3>
+        <h1 className="fs-3 mb-3">{t('title')}</h1>
         <div className="mb-5">
           {t('description')}&nbsp;
           <a href={`/questions/${qid}`}>{questionTitle}</a>

--- a/ui/src/pages/Tags/Detail/index.tsx
+++ b/ui/src/pages/Tags/Detail/index.tsx
@@ -134,14 +134,14 @@ const Index: FC = () => {
           </div>
         ) : (
           <div className="tag-box mb-5">
-            <h3 className="mb-3">
+            <h1 className="fs-3 mb-3">
               <Link
                 to={pathFactory.tagLanding(tagInfo.slug_name)}
                 replace
                 className="link-dark">
                 {tagInfo.display_name}
               </Link>
-            </h3>
+            </h1>
 
             <div
               className="text-break"

--- a/ui/src/pages/Tags/index.tsx
+++ b/ui/src/pages/Tags/index.tsx
@@ -81,7 +81,7 @@ const Tags = () => {
   return (
     <Row className="py-4 mb-4">
       <Col xxl={12}>
-        <h3 className="mb-4">{t('title')}</h3>
+        <h1 className="fs-3 mb-4">{t('title')}</h1>
         <div className="d-block d-sm-flex justify-content-between align-items-center flex-wrap">
           <Stack direction="horizontal" gap={3} className="mb-3 mb-sm-0">
             <Form>

--- a/ui/src/pages/Users/index.tsx
+++ b/ui/src/pages/Users/index.tsx
@@ -43,7 +43,7 @@ const Users = () => {
   return (
     <Row className="py-4 mb-4 d-flex justify-content-center">
       <Col xxl={12}>
-        <h3 className="mb-4">{t('title')}</h3>
+        <h1 className="fs-3 mb-4">{t('title')}</h1>
       </Col>
 
       <Col xxl={12}>
@@ -55,7 +55,7 @@ const Users = () => {
             <Fragment key={key}>
               <Row className="mb-4">
                 <Col>
-                  <h6 className="mb-0">{t(key)}</h6>
+                  <h2 className="fs-6 mb-0">{t(key)}</h2>
                 </Col>
               </Row>
               <Row className={index === keys.length - 1 ? '' : 'mb-4'}>


### PR DESCRIPTION
The question list heading and every entry in it are both `h5`, and most pages
have no `h1` at all.

### Visible on this project's own instance

```console
$ curl -s -A "…Googlebot…" https://meta.answer.dev/questions | grep -c "<h1"
0
```

And in the source, one `h1` in the entire interface — on the question detail
page:

```console
$ grep -rn "<h1" ui/src | wc -l
1
```

### Why it matters

Jumping by heading is one of the two ways people who do not see the page move
around it. With the list heading and its entries on the same level, that walk
is a flat list where a structure was meant; with no `h1`, there is nothing that
names the page. WCAG 1.3.1.

### The change

| where | before | after |
|---|---|---|
| `QuestionList` heading, `source === "questions"` | `h5` | `h1` |
| `QuestionList` heading, elsewhere | `h5` | `h2` |
| `QuestionList` entries | `h5` | `h3` |
| `Tags/Detail`, `Questions/Linked` page titles | `h3` | `h1` |
| `Tags`, `Users`, `Badges` page titles | `h3` | `h1` |
| `Users` groups (`h6`), `Badges` groups (`h5`) | — | `h2` |

`source === "questions"` is the one place where this heading names the page;
the others bring their own title above it.

`fs-5`, `fs-3` and `fs-6` carry the sizes the old tags had, so **nothing
changes on screen**. Checked with prettier, eslint and tsc.

### Still open

The settings pages and the search results have no heading at all — not a wrong
level, none. Adding one means choosing wording and an i18n key across 45
language files, a different kind of decision than renaming a tag.

Supersedes #1590, which was the second half of this work as a separate pull
request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)