### PR TITLE
fix(ui): give the admin area a main landmark

### DIFF
--- a/ui/src/pages/Admin/index.tsx
+++ b/ui/src/pages/Admin/index.tsx
@@ -36,20 +36,20 @@ const Index: FC = () => {
   });
   return (
     <div className="admin-container d-flex">
-      <div
+      <nav
         className="position-sticky px-3 border-end pt-4 d-none d-xl-block"
         id="pcSideNav">
         <AdminSideNav />
-      </div>
+      </nav>
       <div className="flex-fill w-100">
         <div className="d-flex justify-content-center px-0 px-md-4">
-          <div className="answer-container main-mx-with">
+          <main className="answer-container main-mx-with">
             <Row className="py-4">
               <Col className="page-main flex-auto">
                 <Outlet />
               </Col>
             </Row>
-          </div>
+          </main>
         </div>
         <div className="d-flex justify-content-center px-0 px-md-4">
           <div className="main-mx-with">


### PR DESCRIPTION
Follow-up to #1587, which covered the two layouts that carry the side
navigation. The admin area has a layout of its own and sits directly under
`pages/Layout` in the router, so it was not included there. It covers 28
routes.

Same two changes as in #1587: the wrapper around `Outlet` becomes `main`, the
sidebar container becomes `nav`. Class names untouched, so nothing moves.

### A correction to #1587

That PR names `Users/Settings` and `Legal` as also needing a landmark of their
own. **They do not.** Both are nested inside `SideNavLayout`:

```
pages/Layout
  pages/SideNavLayout
    pages/Users/Settings   ← already inside the main added by #1587
  pages/Admin              ← this PR
  pages/SideNavLayoutWithoutFooter
pages/Layout
  pages/SideNavLayout
    pages/Legal            ← already inside it too
```

Adding a second `main` there would be worse than none, since only one per page
is valid. Sorry for the noise in the other description.

### Still open

Twenty routes hang directly under `pages/Layout` with no layout of their own —
sign-in, registration, the error pages. Giving each one a landmark means either
twenty edits or a small `PlainLayout` wrapper in the router. That is a
different kind of change and belongs in its own PR; I am happy to send it if
you would like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)