### PR TITLE
fix(ui): give the tag, user and badge pages an h1

### DIFF
--- a/ui/src/pages/Badges/index.tsx
+++ b/ui/src/pages/Badges/index.tsx
@@ -35,11 +35,11 @@ const Index = () => {
 
   return (
     <div className="pt-4 mb-5">
-      <h3 className="mb-4">{t('title')}</h3>
+      <h1 className="fs-3 mb-4">{t('title')}</h1>
       {badgesList?.map((item) => {
         return (
           <div key={item.group_name} className="mb-4">
-            <h5 className="mb-4">{item.group_name}</h5>
+            <h2 className="fs-5 mb-4">{item.group_name}</h2>
             <Row>
               {item.badges?.map((badge) => {
                 return (

--- a/ui/src/pages/Tags/index.tsx
+++ b/ui/src/pages/Tags/index.tsx
@@ -81,7 +81,7 @@ const Tags = () => {
   return (
     <Row className="py-4 mb-4">
       <Col xxl={12}>
-        <h3 className="mb-4">{t('title')}</h3>
+        <h1 className="fs-3 mb-4">{t('title')}</h1>
         <div className="d-block d-sm-flex justify-content-between align-items-center flex-wrap">
           <Stack direction="horizontal" gap={3} className="mb-3 mb-sm-0">
             <Form>

--- a/ui/src/pages/Users/index.tsx
+++ b/ui/src/pages/Users/index.tsx
@@ -43,7 +43,7 @@ const Users = () => {
   return (
     <Row className="py-4 mb-4 d-flex justify-content-center">
       <Col xxl={12}>
-        <h3 className="mb-4">{t('title')}</h3>
+        <h1 className="fs-3 mb-4">{t('title')}</h1>
       </Col>
 
       <Col xxl={12}>
@@ -55,7 +55,7 @@ const Users = () => {
             <Fragment key={key}>
               <Row className="mb-4">
                 <Col>
-                  <h6 className="mb-0">{t(key)}</h6>
+                  <h2 className="fs-6 mb-0">{t(key)}</h2>
                 </Col>
               </Row>
               <Row className={index === keys.length - 1 ? '' : 'mb-4'}>


### PR DESCRIPTION
Follow-up to #1588, which fixed the question list and the two pages that embed
it. Three more pages carry their title as `h3` and have no `h1` at all:

```
ui/src/pages/Tags/index.tsx:84    <h3 className="mb-4">{t("title")}</h3>
ui/src/pages/Users/index.tsx:46   <h3 className="mb-4">{t("title")}</h3>
ui/src/pages/Badges/index.tsx:38  <h3 className="mb-4">{t("title")}</h3>
```

The groups below them jump further than one level — `h6` on the user page,
`h5` on the badge page. Those become `h2`, one step under the title.

| file | before | after |
|---|---|---|
| `Tags/index.tsx` | `h3` title | `h1` |
| `Users/index.tsx` | `h3` title, `h6` groups | `h1`, `h2` |
| `Badges/index.tsx` | `h3` title, `h5` groups | `h1`, `h2` |

`fs-3`, `fs-6` and `fs-5` carry the sizes the old tags had, so **nothing
changes on screen**. Checked with prettier, eslint and tsc.

### Still open

The settings pages and the search results have no heading at all — not a wrong
level, none. Adding one means choosing wording and adding an i18n key across 45
language files, which is a different kind of decision than renaming a tag, so
it is not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)