### PR TITLE
fix(template): four defects in the server-rendered pages

### DIFF
--- a/ui/template/header.html
+++ b/ui/template/header.html
@@ -170,7 +170,7 @@
           <div class="d-none d-xl-block flex-grow-1 me-auto">
             <div class="d-none d-xl-block ps-0 col-lg-8">
               <form action="/search" class="w-100 maxw-400">
-                <input placeholder="Search" name="q" type="search" class="placeholder-search form-control" value="">
+                <input placeholder="{{translator $.language "ui.header.search.placeholder"}}" name="q" type="search" class="placeholder-search form-control" value="">
               </form>
             </div>
             <!-- <div class="xl-none mt-3 pb-1 nav-item">

--- a/ui/template/question-detail.html
+++ b/ui/template/question-detail.html
@@ -68,7 +68,7 @@
             {{range .detail.Tags}}
             <a href="{{$.baseURL}}/tags/{{.SlugName}}"
                 class="badge-tag rounded-1 {{if .Reserved}}badge-tag-reserved{{end}} {{if .Recommend}}badge-tag-required{{end}} m-1">
-              <span class="">{{.SlugName}}</span>
+              <span class="">{{.DisplayName}}</span>
             </a>
             {{end}}
           </div>

--- a/ui/template/question.html
+++ b/ui/template/question.html
@@ -36,7 +36,7 @@
               <div class="d-flex flex-wrap text-secondary small mb-12">
                 <div class="d-flex align-items-center  text-secondary me-1">
                   <a href="{{$.baseURL}}/users/{{.Operator.Username}}">
-                    <img src="{{$.baseURL}}/users/{{.Operator.Avatar}}" width="24px" height="24px" class="rounded-circle me-1" alt="shuai" data-processed="true">
+                    <img src="{{.Operator.Avatar}}" width="24" height="24" class="rounded-circle me-1" alt="{{.Operator.DisplayName}}" data-processed="true">
                     <span class="me-1 name-ellipsis" style="max-width: 300px;">{{.Operator.DisplayName}}</span>
                   </a>
                   <span class="fw-bold" title="Reputation">{{.Operator.Rank}}</span>
@@ -75,7 +75,7 @@
                 <a
                   href="{{$.baseURL}}/tags/{{.SlugName}}"
                   class="badge-tag rounded-1 {{if .Reserved}}badge-tag-reserved{{end}} {{if .Recommend}}badge-tag-required{{end}} me-1">
-                  <span class="">{{.SlugName}}</span>
+                  <span class="">{{.DisplayName}}</span>
                 </a>
                 {{end}}
               </div>

--- a/ui/template/sort-btns.html
+++ b/ui/template/sort-btns.html
@@ -35,19 +35,19 @@
   <a role="button" tabindex="0" href="?order=frequent" class="text-capitalize fit-content d-none d-md-block btn btn-outline-secondary" style="border-top-right-radius: 0.25rem; border-bottom-right-radius: 0.25rem;">
     {{translator ($.language) "ui.question.frequent" }}
   </a>
-  <div role="group" class="show dropdown btn-group">
-    <button type="button" aria-expanded="true" class="dropdown-toggle show btn btn-outline-secondary btn-sm">
+  <div role="group" class="dropdown btn-group">
+    <button type="button" aria-expanded="false" class="dropdown-toggle btn btn-outline-secondary btn-sm">
       {{translator ($.language) "ui.btns.more" }}
     </button>
-    <div x-placement="bottom-start" class="dropdown-menu show" data-popper-reference-hidden="false" data-popper-escaped="false" data-popper-placement="bottom-start" style="position: absolute; inset: 0px auto auto 0px; transform: translate(0px, 33px);">
+    <div class="dropdown-menu">
       <a href="?order=score" aria-selected="false" class="text-capitalize dropdown-item"> {{translator ($.language) "ui.question.score" }}</a>
     </div>
   </div>
 </div>
 
 <div class="dropdown">
-  <button type="button" id="react-aria8245013726-:r5:" aria-expanded="false" class="dropdown-toggle btn btn-outline-secondary btn-sm"><i class="br bi-view-stacked"></i></button>
-  <div x-placement="bottom-end" aria-labelledby="react-aria8245013726-:r5:" class="dropdown-menu dropdown-menu-end" data-popper-reference-hidden="false" data-popper-escaped="false" data-popper-placement="bottom-end" style="position: absolute; inset: 0px 0px auto auto; transform: translate(0px, 33px);">
+  <button type="button" id="question-layout-toggle" aria-expanded="false" class="dropdown-toggle btn btn-outline-secondary btn-sm"><i class="br bi-view-stacked"></i></button>
+  <div aria-labelledby="question-layout-toggle" class="dropdown-menu dropdown-menu-end">
     <h6 class="dropdown-header" role="heading">
       {{translator ($.language) "ui.btns.view" }}
     </h6>

--- a/ui/template/tag-detail.html
+++ b/ui/template/tag-detail.html
@@ -25,7 +25,7 @@
       <div class="page-main flex-auto col">
         <div class="tag-box mb-5">
           <h3 class="mb-3">
-            <a class="link-dark" href="{{$.baseURL}}/tags/{{$.tag.SlugName}}">{{$.tag.SlugName}}</a>
+            <a class="link-dark" href="{{$.baseURL}}/tags/{{$.tag.SlugName}}">{{$.tag.DisplayName}}</a>
           </h3>
           <p class="text-break">{{formatLinkNofollow $.tag.ParsedText}}</p>
         </div>
@@ -80,7 +80,7 @@
                 {{range .Tags }}
                 <a href="{{$.baseURL}}/tags/{{.SlugName}}"
                   class="badge-tag rounded-1 {{if .Reserved}}badge-tag-reserved{{end}} {{if .Recommend}}badge-tag-required{{end}} m-1">
-                  <span class="">{{.SlugName}}</span>
+                  <span class="">{{.DisplayName}}</span>
                 </a>
                 {{end}}
               </div>

--- a/ui/template/tags.html
+++ b/ui/template/tags.html
@@ -54,7 +54,7 @@
             <div class="h-100 card">
               <div class="d-flex flex-column align-items-start card-body">
                 <a href="{{$.baseURL}}/tags/{{.SlugName}}" class="badge-tag rounded-1 mb-3"><span
-                    class="">{{.SlugName}}</span></a>
+                    class="">{{.DisplayName}}</span></a>
                 <div class="small flex-fill text-break text-wrap text-truncate-3 reset-p mb-3">  {{formatLinkNofollow .ParsedText}}
                 </div>
                 <div class="d-flex align-items-center">


### PR DESCRIPTION
Four unrelated defects, all in `ui/template/` — the pages the Go side renders
for search engines and for readers before the interface takes over. Each is a
line or two. They arrive together because they were all found the same way: by
putting those pages in front of visitors instead of only crawlers.

### They are visible on this project's own instance

Fetched from `meta.answer.dev/questions` with a Googlebot user agent:

| defect | occurrences on that one page |
|---|---|
| avatar `src` prefixed with `/users/` | 10 |
| `alt="shuai"` | 10 |
| `width="24px"` (invalid) | 10 |
| sort dropdown shipped opened | 1 |
| captured React id `react-aria…` | 2 |

The first one is easy to check:

```console
$ curl -sI "https://meta.answer.dev/users/https://www.gravatar.com/avatar/f296bdfb…"
HTTP/2 200
content-type: text/html;charset=utf-8
```

An HTML page where an image is expected.

### The four

**Broken avatars in the question list.** `src="{{$.baseURL}}/users/{{.Operator.Avatar}}"`
prefixes a value that already holds the full reference — as the output above
shows, a complete `https://…` address ends up behind `/users/`. The four other
templates that display an avatar use the value directly. In the same tag:
`alt="shuai"` is placeholder text from a copied DOM, now the display name; and
`width="24px"` is invalid, because HTML dimension attributes take no unit, so
browsers discard it, fall back to the intrinsic size and every row of the list
grows.

**The sort dropdown ships opened.** `class="show"` on the group, the toggle and
the menu, `aria-expanded="true"`, and the inline coordinates Popper had written
when that markup was captured. Without the interface the menu stands open over
the page, and assistive technology is told a collapsed control is expanded. The
same file carries `id="react-aria8245013726-:r5:"`, referenced by an
`aria-labelledby`; replaced with a stable name.

**The search placeholder is not translated.** `placeholder="Search"` written
literally, though the key exists in all 45 language files as
`ui.header.search.placeholder`. Invisible on an English instance, one English
word in the middle of every other one.

**Tags print their slug, not their display name.** For Latin script that is a
matter of case; elsewhere the slug is a transliteration, so a tag named 眼镜
renders as `yan-jing`. Changed in four templates — text only, every `href`
keeps the slug. This is the one of the four that does *not* show on
`meta.answer.dev`, where every tag is a lowercase English word and the two are
identical.

### Verified

All 14 templates parse before and after (`html/template.ParseFiles` with the
project's function map).

Replaces #1583, #1584, #1585 and #1586, which are the same four changes as
separate pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)