### PR TITLE
charts: support using an existing PVC via persistence.existingClaim

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "answer.fullname" . }}-claim
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-claim" (include "answer.fullname" .)) }}
           {{- else }}
           emptyDir: {}
           {{- end -}}

--- a/charts/templates/pvc.yaml
+++ b/charts/templates/pvc.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{ if .Values.persistence.enabled -}}
+{{ if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -91,6 +91,8 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
   annotations: {}
+  # Use an existing PVC instead of creating one; when set, no PVC is created by this chart
+  existingClaim: ""
   # To restore a PVC from a VolumeSnapshot, set the dataSource;
   # the kind and apiGroup are optional and default to the shown values
   dataSource: {}


### PR DESCRIPTION
Add a new `persistence.existingClaim` value that, when set, causes the deployment to mount the specified PVC instead of the chart-managed one and skips creation of the PVC resource entirely.

Tested using an existing PVC that supports ReadWriteMany.