### PR TITLE
fix: comment url swaps title and answer id

### DIFF
--- a/pkg/display/url.go
+++ b/pkg/display/url.go
@@ -54,7 +54,7 @@ func AnswerURL(permalink int, siteUrl, questionID, title, answerID string) strin
 // CommentURL get comment url
 func CommentURL(permalink int, siteUrl, questionID, title, answerID, commentID string) string {
 	if len(answerID) > 0 {
-		return AnswerURL(permalink, siteUrl, questionID, answerID, title) + "?commentId=" + commentID
+		return AnswerURL(permalink, siteUrl, questionID, title, answerID) + "?commentId=" + commentID
 	}
 	return QuestionURL(permalink, siteUrl, questionID, title) + "?commentId=" + commentID
 }

--- a/pkg/display/url_test.go
+++ b/pkg/display/url_test.go
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package display
+
+import (
+	"testing"
+
+	"github.com/apache/answer/internal/base/constant"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testSiteURL    = "https://example.com"
+	testQuestionID = "10010000000000001"
+	testTitle      = "How to install Answer"
+	testAnswerID   = "10020000000000002"
+	testCommentID  = "10030000000000003"
+)
+
+// CommentURL passed title and answerID to AnswerURL in the wrong order, so a
+// comment on an answer linked to a URL built from the title where the answer id
+// belongs. Under the short id permalinks the raw title, spaces and all, ended up
+// in the path.
+func TestCommentURLOnAnswer(t *testing.T) {
+	cases := []struct {
+		name      string
+		permalink int
+		want      string
+	}{
+		{
+			name:      "question id and title",
+			permalink: constant.PermalinkQuestionIDAndTitle,
+			want:      "https://example.com/questions/10010000000000001/how-to-install-answer/10020000000000002?commentId=10030000000000003",
+		},
+		{
+			name:      "question id",
+			permalink: constant.PermalinkQuestionID,
+			want:      "https://example.com/questions/10010000000000001/10020000000000002?commentId=10030000000000003",
+		},
+		{
+			name:      "question id and title by short id",
+			permalink: constant.PermalinkQuestionIDAndTitleByShortID,
+			want:      "https://example.com/questions/D1D1/how-to-install-answer/E1E1?commentId=10030000000000003",
+		},
+		{
+			name:      "question id by short id",
+			permalink: constant.PermalinkQuestionIDByShortID,
+			want:      "https://example.com/questions/D1D1/E1E1?commentId=10030000000000003",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CommentURL(tc.permalink, testSiteURL, testQuestionID, testTitle, testAnswerID, testCommentID)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t,
+				AnswerURL(tc.permalink, testSiteURL, testQuestionID, testTitle, testAnswerID)+"?commentId="+testCommentID,
+				got,
+				"a comment on an answer should be the answer URL plus the comment query")
+		})
+	}
+}
+
+// A comment on the question itself takes the other branch, which was already
+// correct. Pin it so the fix above stays scoped to the answer branch.
+func TestCommentURLOnQuestion(t *testing.T) {
+	cases := []struct {
+		name      string
+		permalink int
+		want      string
+	}{
+		{
+			name:      "question id and title",
+			permalink: constant.PermalinkQuestionIDAndTitle,
+			want:      "https://example.com/questions/10010000000000001/how-to-install-answer?commentId=10030000000000003",
+		},
+		{
+			name:      "question id",
+			permalink: constant.PermalinkQuestionID,
+			want:      "https://example.com/questions/10010000000000001?commentId=10030000000000003",
+		},
+		{
+			name:      "question id and title by short id",
+			permalink: constant.PermalinkQuestionIDAndTitleByShortID,
+			want:      "https://example.com/questions/D1D1/how-to-install-answer?commentId=10030000000000003",
+		},
+		{
+			name:      "question id by short id",
+			permalink: constant.PermalinkQuestionIDByShortID,
+			want:      "https://example.com/questions/D1D1?commentId=10030000000000003",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CommentURL(tc.permalink, testSiteURL, testQuestionID, testTitle, "", testCommentID)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed Changes

A comment left on an answer links to the wrong URL. `CommentURL` calls its sibling `AnswerURL` with the last two arguments reversed:

```go
// pkg/display/url.go:57
return AnswerURL(permalink, siteUrl, questionID, answerID, title) + "?commentId=" + commentID

// pkg/display/url.go:44
func AnswerURL(permalink int, siteUrl, questionID, title, answerID string) string
```

The answer route is `/questions/:id/:title/:answerid` (`internal/router/template_router.go:71`, and `questions/:qid/:slugPermalink/:aid` in `ui/src/router/routes.ts:116`), so the answer id ends up in the title slot and the title ends up in the answer id slot. What the title then becomes depends on the permalink setting: the numeric ones send it through `uid.DeShortID`, which parses it as a short id and returns an unrelated number, and the short id ones send it through `uid.EnShortID`, which returns non-numeric input unchanged, so the raw title with its spaces is written straight into the path.

For question `10010000000000001`, title `How to install Answer`, answer `10020000000000002`, comment `10030000000000003`:

```
permalink 1  got  /questions/10010000000000001/10020000000000002/1846951505924529392?commentId=10030000000000003
             want /questions/10010000000000001/how-to-install-answer/10020000000000002?commentId=10030000000000003
permalink 2  got  /questions/10010000000000001/1846951505924529392?commentId=10030000000000003
             want /questions/10010000000000001/10020000000000002?commentId=10030000000000003
permalink 3  got  /questions/D1D1/10020000000000002/How to install Answer?commentId=10030000000000003
             want /questions/D1D1/how-to-install-answer/E1E1?commentId=10030000000000003
permalink 4  got  /questions/D1D1/How to install Answer?commentId=10030000000000003
             want /questions/D1D1/E1E1?commentId=10030000000000003
```

This is what readers click in the new comment notification email built in `internal/service/export/email_service.go:314`, and it is the `CommentUrl` handed to notification plugins in `internal/service/notification_common/notification.go:399`. Both call sites already pass the arguments in the order `CommentURL` declares, so the swap is entirely inside `CommentURL`. A comment on a question takes the other branch, which was already correct.

  - Pass `title` and `answerID` to `AnswerURL` in the order it declares them, so a comment on an answer is the answer URL plus the comment query
  - Add `pkg/display/url_test.go` covering both branches across all four permalink settings

## Testing

Against `dev` at 947a48b, the new test fails on all four permalink settings for a comment on an answer, and the four question cases pass, which is the branch that was already correct. With the one line changed:

```
go test ./pkg/display/ -v   ok, 8 subtests pass
go test ./pkg/...           all packages ok
go build ./...              ok
go vet ./pkg/display/... ./internal/service/export/... ./internal/service/notification_common/...   ok
golangci-lint run ./pkg/display/...  (v2.6.2, repo .golangci.yaml)   0 issues
go mod tidy                 no change to go.mod or go.sum
```

No existing test referenced `CommentURL`, so nothing else needed updating. The test uses an ASCII title, which `htmltext.UrlTitle` slugifies identically regardless of the `transliterateNonLatin` setting, locale or timezone.
