### PR TITLE
fix: lowercase the email before hashing the Gravatar URL

### DIFF
--- a/pkg/gravatar/gravatar.go
+++ b/pkg/gravatar/gravatar.go
@@ -29,7 +29,7 @@ import (
 
 // GetAvatarURL get avatar url from gravatar by email
 func GetAvatarURL(baseURL, email string) string {
-	hasher := sha256.Sum256([]byte(strings.TrimSpace(email)))
+	hasher := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(email))))
 	hash := hex.EncodeToString(hasher[:])
 	return baseURL + hash
 }

--- a/pkg/gravatar/gravatar_test.go
+++ b/pkg/gravatar/gravatar_test.go
@@ -41,6 +41,21 @@ func TestGetAvatarURL(t *testing.T) {
 			args: args{email: "answer@answer.com"},
 			want: "https://www.gravatar.com/avatar/7296942c1f63d97f6c124705142009867638f7b3dbcdadd0cb1bcb40e427eb8e",
 		},
+		{
+			name: "mixed case address",
+			args: args{email: "Answer@Answer.com"},
+			want: "https://www.gravatar.com/avatar/7296942c1f63d97f6c124705142009867638f7b3dbcdadd0cb1bcb40e427eb8e",
+		},
+		{
+			name: "upper case address",
+			args: args{email: "ANSWER@ANSWER.COM"},
+			want: "https://www.gravatar.com/avatar/7296942c1f63d97f6c124705142009867638f7b3dbcdadd0cb1bcb40e427eb8e",
+		},
+		{
+			name: "padded mixed case address",
+			args: args{email: "  Answer@Answer.com  "},
+			want: "https://www.gravatar.com/avatar/7296942c1f63d97f6c124705142009867638f7b3dbcdadd0cb1bcb40e427eb8e",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1604

## Proposed Changes

  - Lowercase the email address in `pkg/gravatar.GetAvatarURL` before hashing
    it. The Gravatar specification hashes the trimmed, lowercased address; the
    function only trimmed, so an account whose stored address contains an
    uppercase letter hashed to an address Gravatar does not know and rendered
    the identicon fallback instead of the user's avatar.
  - Add `pkg/gravatar/gravatar_test.go` covering the casing and whitespace
    variants of one address, all of which must produce the hash of its
    lowercase form.

`selectedAvatar` recomputes this URL from the stored address on every response,
so this affects both `default_avatar: gravatar` and an explicit per-user
`avatar.type: gravatar` — a user cannot work around it by re-selecting Gravatar
in their profile. The backend never normalises a stored address, and the
external-login path copies the provider's address verbatim, so accounts created
through an OIDC/OAuth2 connector inherit whatever casing the identity provider
sends.

The web UI already lowercases before hashing
(`ui/src/pages/Users/Settings/Profile/index.tsx`), so this also removes a
frontend/backend disagreement: the Settings → Profile preview showed the user's
real avatar while every other surface showed an identicon.

No migration is needed. The hash is computed on read, so existing accounts
resolve correctly as soon as this ships; stored addresses are left untouched.
