### PR TITLE
fix(ui): add the AI prompt to admin settings and stop resetting it

### DIFF
--- a/i18n/en_US.yaml
+++ b/i18n/en_US.yaml
@@ -2360,6 +2360,16 @@ ui:
       model:
         label: Model
         msg: Model is required
+      prompt:
+        label: Prompt
+        text: >-
+          Instructions sent to the model with every question. Use %s where the
+          user's question should be inserted. Leave empty to use the built-in
+          default.
+        msg: >-
+          The prompt must contain %s exactly once, marking where the user's
+          question is inserted, and no other format verb. Write %% for a
+          literal percent sign.
       add_success: AI settings updated successfully.
     conversations:
       topic: Topic

--- a/ui/src/common/interface.ts
+++ b/ui/src/common/interface.ts
@@ -835,6 +835,10 @@ export interface AiConfig {
     api_key: string;
     model: string;
   }>;
+  prompt_config?: {
+    zh_cn: string;
+    en_us: string;
+  };
 }
 
 export interface AiProviderItem {

--- a/ui/src/pages/Admin/AiSettings/index.tsx
+++ b/ui/src/pages/Admin/AiSettings/index.tsx
@@ -68,6 +68,11 @@ const Index = () => {
       isInvalid: false,
       errorMsg: '',
     },
+    prompt: {
+      value: '',
+      isInvalid: false,
+      errorMsg: '',
+    },
   });
   const [apiHostPlaceholder, setApiHostPlaceholder] = useState('');
   const [modelsData, setModels] = useState<{ id: string }[]>([]);
@@ -169,7 +174,7 @@ const Index = () => {
   const checkValidate = () => {
     let bol = true;
 
-    const { api_host, api_key, model } = formData;
+    const { api_host, api_key, model, prompt } = formData;
 
     if (!api_host.value) {
       bol = false;
@@ -197,6 +202,25 @@ const Index = () => {
         isInvalid: true,
         errorMsg: t('model.msg'),
       };
+    }
+
+    // The prompt is a format template: the backend runs it through
+    // fmt.Sprintf with the user's question, so it needs exactly one %s and no
+    // other verb. Getting this wrong fails quietly -- Go appends
+    // %!(EXTRA string=...) and the question never reaches the model -- so
+    // reject it here rather than at answer time. An empty prompt is valid and
+    // means the built-in default.
+    if (prompt.value) {
+      const verbs = prompt.value.replace(/%%/g, '').match(/%./g) || [];
+      const questionVerbs = verbs.filter((verb) => verb === '%s');
+      if (questionVerbs.length !== 1 || verbs.length !== questionVerbs.length) {
+        bol = false;
+        formData.prompt = {
+          ...formData.prompt,
+          isInvalid: true,
+          errorMsg: t('prompt.msg'),
+        };
+      }
     }
 
     setFormData({
@@ -227,6 +251,10 @@ const Index = () => {
       enabled: formData.enabled.value,
       chosen_provider: formData.provider.value,
       ai_providers: newProviders,
+      prompt_config: {
+        zh_cn: historyConfigRef.current?.prompt_config?.zh_cn || '',
+        en_us: formData.prompt.value,
+      },
     };
     saveAiConfig(params)
       .then(() => {
@@ -292,6 +320,11 @@ const Index = () => {
       },
       model: {
         value: currentAiConfig?.model || '',
+        isInvalid: false,
+        errorMsg: '',
+      },
+      prompt: {
+        value: aiConfig.prompt_config?.en_us || '',
         isInvalid: false,
         errorMsg: '',
       },
@@ -476,6 +509,29 @@ const Index = () => {
 
             <div className="invalid-feedback">{formData.model.errorMsg}</div>
           </div>
+
+          <Form.Group controlId="prompt" className="mb-3">
+            <Form.Label>{t('prompt.label')}</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={8}
+              value={formData.prompt.value}
+              isInvalid={formData.prompt.isInvalid}
+              onChange={(e) =>
+                handleValueChange({
+                  prompt: {
+                    value: e.target.value,
+                    errorMsg: '',
+                    isInvalid: false,
+                  },
+                })
+              }
+            />
+            <Form.Text className="text-muted">{t('prompt.text')}</Form.Text>
+            <Form.Control.Feedback type="invalid">
+              {formData.prompt.errorMsg}
+            </Form.Control.Feedback>
+          </Form.Group>
 
           <Button type="submit">{t('save', { keyPrefix: 'btns' })}</Button>
         </Form>


### PR DESCRIPTION
Fixes #1608

## Proposed Changes

  - Add a **Prompt** field to Admin → AI Settings, prefilled from the stored `prompt_config.en_us`, so the assistant's prompt can be edited in the UI at all.
  - Send `prompt_config` in the save payload, which stops `SaveSiteAI` from replacing the stored prompt with `DefaultAIPromptConfigEnUS` on every save.
  - Validate the template on save: exactly one `%s` and no other format verb, since `getPromptByLanguage` runs the prompt through `fmt.Sprintf`.
  - Preserve `zh_cn` from the loaded config rather than dropping it, so editing the English prompt does not clear the Chinese one.
  - Add `prompt_config` to the `AiConfig` type and the `ui.admin.ai_settings.prompt` strings to `i18n/en_US.yaml`.

## Why

`SaveSiteAI` substitutes the defaults when a request omits `prompt_config`, and the admin form built its payload from `enabled`, `chosen_provider` and `ai_providers` only. So the prompt was unreachable from the UI, and a prompt set through the API reverted silently the next time anyone saved the model or the API key.

This is frontend-only: the backend already accepts, persists and returns `prompt_config`, and `getPromptByLanguage` already falls back to the constant when the stored prompt is empty. Leaving the field empty therefore restores the default.

## On the validation

Once the prompt is editable, the `%s` becomes easy to lose — and losing it fails quietly. `fmt.Sprintf` appends `%!(EXTRA string=...)` and the user's question never reaches the model, so the assistant answers from nothing with no error anywhere. The form now rejects that instead.

The rule is exactly one `%s` and no other verb; `%%` is treated as an escaped literal percent. An empty prompt stays valid and means the built-in default. Cases covered:

| prompt | accepted |
| --- | --- |
| empty | yes — uses the default |
| `... question: %s ...` | yes |
| no `%s` at all | no |
| two `%s` | no |
| `%d` alongside `%s` | no |
| `100%% certain ... %s` | yes |
| `100%% done` (no `%s`) | no |
| `%%s` only (a literal, not a verb) | no |

## Verification

Against `main` (3b9f137):

  - `tsc --noEmit` clean, with the changed file confirmed present in the compilation
  - `eslint` clean on the changed component
  - `i18n/en_US.yaml` parses and the keys resolve at `ui.admin.ai_settings.prompt`
  - validation predicate exercised against the eight cases in the table above
  - built into a running image and exercised end to end: the field renders prefilled with the stored prompt, an edit survives Save and a page reload, and the saved value is the one served back by `GET /answer/admin/api/ai-config`
